### PR TITLE
Feat: 카카오 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -25,14 +25,14 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	//implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	//testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-maven-plugin:3.3.5'
 }

--- a/src/main/java/itstime/reflog/config/SecurityConfig.java
+++ b/src/main/java/itstime/reflog/config/SecurityConfig.java
@@ -1,0 +1,62 @@
+package itstime.reflog.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import lombok.RequiredArgsConstructor;
+
+@EnableWebSecurity
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+	private final OAuth2SuccessHandler successHandler;
+	private final CustomOAuth2UserService customOAuthService;
+	private final MemberRepository memberRepository;
+
+
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration corsConfiguration = new CorsConfiguration();
+
+		corsConfiguration.setAllowedOriginPatterns(List.of("*"));
+		corsConfiguration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE","PATCH", "HEAD", "OPTIONS"));
+		corsConfiguration.setAllowedHeaders(List.of("Authorization", "Cache-Control", "Content-Type"));
+		corsConfiguration.setAllowCredentials(true);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", corsConfiguration);
+
+		return source;
+	}
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		http
+			.authorizeHttpRequests(requests -> requests
+				.requestMatchers("/test", "/swagger-ui/index.html", "/swagger-ui/**", "/v3/api-docs/**","/swagger-resources/**", "/v3/api-docs").permitAll()
+				.anyRequest().authenticated()           // 나머지 URL은 인증 필요
+			)
+			// .addFilterBefore(new TokenAuthenticationFilter(jwtTokenProvider()), UsernamePasswordAuthenticationFilter.class)
+			.formLogin(FormLoginConfigurer::disable)
+			// OAuth 로그인 설정
+			.oauth2Login(customConfigurer -> customConfigurer
+				.successHandler(successHandler)
+				.userInfoEndpoint(endpointConfig -> endpointConfig.userService(customOAuthService))
+			)
+			.cors(httpSecurityCorsConfigurer -> httpSecurityCorsConfigurer.configurationSource(corsConfigurationSource()))
+			.csrf(AbstractHttpConfigurer::disable);
+		return http.build();
+	}
+
+}

--- a/src/main/java/itstime/reflog/config/SecurityConfig.java
+++ b/src/main/java/itstime/reflog/config/SecurityConfig.java
@@ -14,6 +14,9 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import itstime.reflog.member.repository.MemberRepository;
+import itstime.reflog.oauth.handler.OAuth2SuccessHandler;
+import itstime.reflog.oauth.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 
 @EnableWebSecurity

--- a/src/main/java/itstime/reflog/member/domain/Member.java
+++ b/src/main/java/itstime/reflog/member/domain/Member.java
@@ -1,0 +1,36 @@
+package itstime.reflog.member.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Member {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String providerId;
+
+	@Enumerated(EnumType.STRING)
+	private ProviderType providerType;
+
+	@Column(nullable = false, unique = true)
+	private String name;
+
+	private String profileImageUrl;
+
+}

--- a/src/main/java/itstime/reflog/member/domain/ProviderType.java
+++ b/src/main/java/itstime/reflog/member/domain/ProviderType.java
@@ -1,0 +1,9 @@
+package itstime.reflog.member.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum ProviderType {
+	NAVER,
+	KAKAO;
+}

--- a/src/main/java/itstime/reflog/member/repository/MemberRepository.java
+++ b/src/main/java/itstime/reflog/member/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package itstime.reflog.member.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import itstime.reflog.member.domain.Member;
+import itstime.reflog.member.domain.ProviderType;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+	Optional<Member> findByProviderIdAndProviderType(String providerId, ProviderType providerType);
+}

--- a/src/main/java/itstime/reflog/oauth/domain/UserPrincipal.java
+++ b/src/main/java/itstime/reflog/oauth/domain/UserPrincipal.java
@@ -1,0 +1,35 @@
+package itstime.reflog.oauth.domain;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import itstime.reflog.member.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserPrincipal implements OAuth2User {
+	private final Member member;
+	private final Map<String, Object> attributes;
+	private final Collection<GrantedAuthority> authorities;
+
+	@Override
+	public Map<String, Object> getAttributes() {
+		return attributes;
+	}
+
+	@Override
+	public String getName() {
+		return member.getName();
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return authorities;
+	}
+}
+

--- a/src/main/java/itstime/reflog/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/itstime/reflog/oauth/handler/OAuth2SuccessHandler.java
@@ -1,0 +1,23 @@
+package itstime.reflog.oauth.handler;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws IOException{
+
+	}
+
+}

--- a/src/main/java/itstime/reflog/oauth/info/OAuth2UserInfo.java
+++ b/src/main/java/itstime/reflog/oauth/info/OAuth2UserInfo.java
@@ -1,0 +1,20 @@
+package itstime.reflog.oauth.info;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+	protected Map<String, Object> attributes;
+
+	public OAuth2UserInfo(Map<String, Object> attributes) {
+		this.attributes = attributes;
+	}
+
+	public Map<String, Object> getAttributes() {
+		return attributes;
+	}
+
+	public abstract String getProviderId();
+	public abstract String getName();
+	public abstract String getProfileImageUrl();
+
+}

--- a/src/main/java/itstime/reflog/oauth/info/OAuth2UserInfoFactory.java
+++ b/src/main/java/itstime/reflog/oauth/info/OAuth2UserInfoFactory.java
@@ -1,0 +1,16 @@
+package itstime.reflog.oauth.info;
+
+import java.util.Map;
+
+import itstime.reflog.member.domain.ProviderType;
+import itstime.reflog.oauth.info.impl.KakaoOAuth2UserInfo;
+
+public class OAuth2UserInfoFactory {
+	public static OAuth2UserInfo getOAuth2UserInfo(ProviderType providerType, Map<String, Object> attributes) {
+		switch (providerType) {
+			// case NAVER: return new NaverOAuth2UserInfo(attributes);
+			case KAKAO: return new KakaoOAuth2UserInfo(attributes);
+			default: throw new IllegalArgumentException("Invalid Provider Type.");
+		}
+	}
+}

--- a/src/main/java/itstime/reflog/oauth/info/impl/KakaoOAuth2UserInfo.java
+++ b/src/main/java/itstime/reflog/oauth/info/impl/KakaoOAuth2UserInfo.java
@@ -1,0 +1,37 @@
+package itstime.reflog.oauth.info.impl;
+
+import java.util.Map;
+
+import itstime.reflog.oauth.info.OAuth2UserInfo;
+
+public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
+
+	public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+		super(attributes);
+	}
+
+	@Override
+	public String getProviderId() {
+		return attributes.get("id").toString();
+	}
+
+	@Override
+	public String getName() {
+		Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+
+		if (properties == null) {
+			return null;
+		}
+
+		return (String) properties.get("nickname");
+	}
+
+	@Override
+	public String getProfileImageUrl(){
+		Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+		if (properties == null) {
+			return null;
+		}
+		return (String) properties.get("profile_image");
+	}
+}

--- a/src/main/java/itstime/reflog/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/itstime/reflog/oauth/service/CustomOAuth2UserService.java
@@ -1,0 +1,73 @@
+package itstime.reflog.oauth.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import itstime.reflog.member.domain.Member;
+import itstime.reflog.member.domain.ProviderType;
+import itstime.reflog.member.repository.MemberRepository;
+import itstime.reflog.oauth.domain.UserPrincipal;
+import itstime.reflog.oauth.info.OAuth2UserInfo;
+import itstime.reflog.oauth.info.OAuth2UserInfoFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User>{
+
+	private final MemberRepository memberRepository;
+	@Override
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+		OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+		OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+		// 소셜 로그인 식별 필드
+		String providerTypeKey = userRequest.getClientRegistration().getRegistrationId().toUpperCase();
+		ProviderType providerType = ProviderType.valueOf(providerTypeKey);
+
+		// 전달받은 사용자 속성
+		Map<String, Object> attributes = oAuth2User.getAttributes();
+
+		// OAuth2UserInfo를 통해 특정 Provider에 맞는 사용자 정보를 가져옴
+		OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(providerType, attributes);
+
+		// 사용자 정보 조회 시 providerId 사용
+		String providerId = oAuth2UserInfo.getProviderId();
+
+		// 사용자 정보를 확인하고, 없는 경우 새로 저장
+		Member member = getOrCreateMember(providerId,providerType, oAuth2UserInfo);
+
+		// 권한 설정 (기본 권한 USER로 설정)
+		List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+
+		// Security Context에 저장할 사용자 정보 생성
+		return new UserPrincipal(member, attributes, authorities);
+	}
+
+	// DB에서 사용자 정보를 조회하거나 없는 경우 새로 생성
+	private Member getOrCreateMember(String providerId, ProviderType providerType, OAuth2UserInfo oAuth2UserInfo) {
+		Optional<Member> memberOptional = memberRepository.findByProviderIdAndProviderType(providerId, providerType);
+
+		return memberOptional.orElseGet(() -> {
+			Member newMember = Member.builder()
+				.name(oAuth2UserInfo.getName())
+				.providerId(providerId)
+				.profileImageUrl(oAuth2UserInfo.getProfileImageUrl())
+				.providerType(providerType)
+				.build();
+			return memberRepository.save(newMember);
+		});
+	}
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -4,5 +4,34 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    open-in-view: false
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            clientAuthenticationMethod: client_secret_post
+            authorizationGrantType: authorization_code
+            redirectUri: "http://localhost:8080/login/oauth2/code/kakao"
+            scope:
+              - profile_nickname
+              - profile_image
+            clientName: Kakao
+        provider:
+          kakao:
+            authorizationUri: https://kauth.kakao.com/oauth/authorize
+            tokenUri: https://kauth.kakao.com/oauth/token
+            userInfoUri: https://kapi.kakao.com/v2/user/me
+            userNameAttribute: id
+
 server:
   port: 8080


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #5 

## 🔑 Key Changes

1. 내용
    - Member 엔티티 : providerId, ProviderType, name, ProfileURl 필드 추가, providerId 는 로그인을 했을 때 db에 사용자가 없을 경우 새로 저장을 하게 되는데 이때 사용자 조회시 사용하게 됨
    
    - SecurityConfig 설정 : CORS 오류를 해결하기 위한 설정 추가, CustomOAuth2UserService로 사용자 정보를 가져오게 설정, 로그인 성공 시 successHandler를 호출 (여기는 아직 구현을 안했는데 로그인 성공 시 jwt 발급 받는 코드가 여기 들어오면 되고 로그인 했을 때 redirect url도 여기서 설정해주면 됨 -> 아직 아무것도 설정을 안해서 로그인 이후 http://localhost:8080/login/oauth2/code/kakao?code= 여기서 멈추게 됨)
    
    - ProviderType 열거형 추가로 로그인 제공자 관리 : 여기에 kakao와 naver 추가했음
    
    - KakaoOAuth2UserInfo 및 OAuth2UserInfoFactory 구현 : KakaoOAuth2UserInfo 클래스를 추가하여 카카오 로그인 시 사용자 정보를 처리, Naver 로그인 구현 시에 NaverOAuth2UserInfo 클래스 만들어서 구현하면 됨,  OAuth2UserInfoFactory 클래스에서 ProviderType에 따라 적절한 OAuth2UserInfo 객체 반환하도록 구현
    
    - CustomOAuth2UserService에서 OAuth2 로그인 사용자 정보 조회 및 저장 : OAuth2 로그인 시 사용자 정보를 조회하고 데이터베이스에 저장, 여기서 기본 권한을 부여하게 구현했는데 이거 이렇게 해도 되는지.. 코드 리뷰 부탁
    
    - MemberRepository 인터페이스에 사용자 조회 메서드 추가 : roviderId와 providerType을 기준으로 사용자를 조회하는 메서드를 추가
    
    - http://localhost:8080/oauth2/authorization/kakao 여기에 접속하게 되면 로그인 진행 가능
    
    - 카카오 로그인 하면서 환경변수가 추가되었기에 github-actions.yml 수정해야함
    
    - 패키지 구조 괜찮은지 피드백 부탁!


    
## 📸 Screenshot
![image](https://github.com/user-attachments/assets/993d07d4-7d4a-4d82-8e64-479cca49cb48)
![image](https://github.com/user-attachments/assets/67cf905e-bd2e-499f-83f3-26c866c4122a)

