### PR TITLE
Feat: 투두리스트 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-maven-plugin:3.3.5'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 }
 

--- a/src/main/java/itstime/reflog/common/CommonApiResponse.java
+++ b/src/main/java/itstime/reflog/common/CommonApiResponse.java
@@ -13,7 +13,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @JsonPropertyOrder({"isSuccess", "code", "message", "result"})
-public class ApiResponse<T> {
+public class CommonApiResponse<T> {
 
 	@JsonProperty("isSuccess")
 	private final Boolean isSuccess;
@@ -23,16 +23,16 @@ public class ApiResponse<T> {
 	private T result;
 
 	// 성공한 경우 응답 생성
-	public static <T> ApiResponse<T> onSuccess(T result){
-		return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
+	public static <T> CommonApiResponse<T> onSuccess(T result){
+		return new CommonApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
 	}
 
-	public static <T> ApiResponse<T> of(BaseCode code, T result){
-		return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
+	public static <T> CommonApiResponse<T> of(BaseCode code, T result){
+		return new CommonApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
 	}
 
 	// 실패한 경우 응답 생성
-	public static <T> ApiResponse<T> onFailure(String code, String message, T data) {
-		return new ApiResponse<>(true, code, message, data);
+	public static <T> CommonApiResponse<T> onFailure(String code, String message, T data) {
+		return new CommonApiResponse<>(false, code, message, data);
 	}
 }

--- a/src/main/java/itstime/reflog/common/code/status/ErrorStatus.java
+++ b/src/main/java/itstime/reflog/common/code/status/ErrorStatus.java
@@ -18,6 +18,10 @@ public enum ErrorStatus implements BaseErrorCode {
 	_FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
 	// 멤버 관련 에러
+	_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "해당 회원을 찾을 수 없습니다."),
+	_DUPLICATE_MEMBER(HttpStatus.CONFLICT, "MEMBER409", "이미 존재하는 회원입니다."),
+	_INVALID_MEMBER_CREDENTIALS(HttpStatus.UNAUTHORIZED, "MEMBER401", "잘못된 인증 정보입니다."),
+	_MEMBER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "MEMBER403", "해당 회원은 권한이 없습니다."),
 
 	// ...~
 	;

--- a/src/main/java/itstime/reflog/common/code/status/ErrorStatus.java
+++ b/src/main/java/itstime/reflog/common/code/status/ErrorStatus.java
@@ -23,7 +23,9 @@ public enum ErrorStatus implements BaseErrorCode {
 	_INVALID_MEMBER_CREDENTIALS(HttpStatus.UNAUTHORIZED, "MEMBER401", "잘못된 인증 정보입니다."),
 	_MEMBER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "MEMBER403", "해당 회원은 권한이 없습니다."),
 
-	// ...~
+	// TodoList 관련 에러
+	_TODO_NOT_FOUND(HttpStatus.NOT_FOUND, "TODO404", "해당 투두리스트를 찾을 수 없습니다."),
+	_TODO_UPDATE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "TODO403", "투두리스트를 수정할 권한이 없습니다.");
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/itstime/reflog/common/exception/ExceptionAdvice.java
+++ b/src/main/java/itstime/reflog/common/exception/ExceptionAdvice.java
@@ -16,7 +16,7 @@ import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import itstime.reflog.common.ApiResponse;
+import itstime.reflog.common.CommonApiResponse;
 import itstime.reflog.common.code.ErrorReasonDTO;
 import itstime.reflog.common.code.status.ErrorStatus;
 import jakarta.servlet.http.HttpServletRequest;
@@ -69,7 +69,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 	private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDTO reason,
 		HttpHeaders headers, HttpServletRequest request) {
 
-		ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(),reason.getMessage(),null);
+		CommonApiResponse<Object> body = CommonApiResponse.onFailure(reason.getCode(),reason.getMessage(),null);
 		//        e.printStackTrace();
 
 		WebRequest webRequest = new ServletWebRequest(request);
@@ -84,7 +84,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
 	private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
 		HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
-		ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorPoint);
+		CommonApiResponse<Object> body = CommonApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorPoint);
 		return super.handleExceptionInternal(
 			e,
 			body,
@@ -96,7 +96,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
 	private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
 		WebRequest request, Map<String, String> errorArgs) {
-		ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
+		CommonApiResponse<Object> body = CommonApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
 		return super.handleExceptionInternal(
 			e,
 			body,
@@ -108,7 +108,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
 	private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
 		HttpHeaders headers, WebRequest request) {
-		ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+		CommonApiResponse<Object> body = CommonApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
 		return super.handleExceptionInternal(
 			e,
 			body,

--- a/src/main/java/itstime/reflog/config/SecurityConfig.java
+++ b/src/main/java/itstime/reflog/config/SecurityConfig.java
@@ -42,12 +42,11 @@ public class SecurityConfig {
 
 		return source;
 	}
-
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http
 			.authorizeHttpRequests(requests -> requests
-				.requestMatchers("/test", "/swagger-ui/index.html", "/swagger-ui/**", "/v3/api-docs/**","/swagger-resources/**", "/v3/api-docs").permitAll()
+				.requestMatchers("/test", "/swagger-ui/index.html", "/swagger-ui/**", "/v3/api-docs/**","/swagger-resources/**", "/v3/api-docs", "/api/v1/todo/**").permitAll()
 				.anyRequest().authenticated()           // 나머지 URL은 인증 필요
 			)
 			// .addFilterBefore(new TokenAuthenticationFilter(jwtTokenProvider()), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/itstime/reflog/member/domain/Member.java
+++ b/src/main/java/itstime/reflog/member/domain/Member.java
@@ -1,5 +1,9 @@
 package itstime.reflog.member.domain;
 
+import java.util.List;
+
+import itstime.reflog.todolist.domain.Todolist;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -7,6 +11,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -32,5 +37,9 @@ public class Member {
 	private String name;
 
 	private String profileImageUrl;
+
+	@OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+	private List<Todolist> todolists;
+
 
 }

--- a/src/main/java/itstime/reflog/todolist/controller/TodolistController.java
+++ b/src/main/java/itstime/reflog/todolist/controller/TodolistController.java
@@ -1,9 +1,15 @@
 package itstime.reflog.todolist.controller;
 
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -33,8 +39,8 @@ public class TodolistController {
 				description = "투두리스트 생성 성공"
 			),
 			@ApiResponse(
-				responseCode = "400",
-				description = "잘못된 요청 데이터"
+				responseCode = "404",
+				description = "해당 회원을 찾을 수 없음"
 			),
 			@ApiResponse(
 				responseCode = "500",
@@ -47,4 +53,38 @@ public class TodolistController {
 		todolistService.createTodolist(dto);
 		return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
 	}
+
+	@Operation(
+		summary = "투두리스트 조회 API",
+		description = "특정 회원의 특정 날짜에 해당하는 투두리스트를 조회합니다.",
+		responses = {
+			@ApiResponse(
+				responseCode = "200",
+				description = "투두리스트 조회 성공",
+				content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+			),
+			@ApiResponse(
+				responseCode = "404",
+				description = "해당 회원 또는 투두리스트를 찾을 수 없음",
+				content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+			),
+			@ApiResponse(
+				responseCode = "500",
+				description = "서버 에러",
+				content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+			)
+		}
+	)
+	@GetMapping("/todolist")
+	public ResponseEntity<CommonApiResponse<List<TodolistDTO.TodolistResponse>>> getTodolistByMemberIdAndDate(
+		@RequestParam Long memberId,
+		@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+	) {
+		List<TodolistDTO.TodolistResponse> todolists = todolistService.getTodolistByMemberIdAndDate(memberId, date);
+		return ResponseEntity.ok(CommonApiResponse.onSuccess(todolists));
+	}
+
+
+
+
 }

--- a/src/main/java/itstime/reflog/todolist/controller/TodolistController.java
+++ b/src/main/java/itstime/reflog/todolist/controller/TodolistController.java
@@ -54,8 +54,11 @@ public class TodolistController {
 		}
 	)
 	@PostMapping("/todolist")
-	public ResponseEntity<CommonApiResponse<Void>> createTodolist(@RequestBody TodolistDTO.TodolistSaveOrUpdateRequest dto) {
-		todolistService.createTodolist(dto);
+	public ResponseEntity<CommonApiResponse<Void>> createTodolist(
+		@RequestParam Long memberId,
+		@RequestBody TodolistDTO.TodolistSaveOrUpdateRequest dto
+	) {
+		todolistService.createTodolist(memberId, dto);
 		return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
 	}
 
@@ -120,9 +123,10 @@ public class TodolistController {
 	@PatchMapping("/todolist/{todolistId}")
 	public ResponseEntity<CommonApiResponse<Void>> updateTodolist(
 		@PathVariable Long todolistId,
+		@RequestParam Long memberId,
 		@RequestBody @Valid TodolistDTO.TodolistSaveOrUpdateRequest request
 	) {
-		todolistService.updateTodolist(todolistId, request);
+		todolistService.updateTodolist(todolistId, memberId, request);
 		return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
 	}
 

--- a/src/main/java/itstime/reflog/todolist/controller/TodolistController.java
+++ b/src/main/java/itstime/reflog/todolist/controller/TodolistController.java
@@ -6,6 +6,8 @@ import java.util.List;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,6 +23,7 @@ import itstime.reflog.common.code.ErrorReasonDTO;
 import itstime.reflog.common.code.status.ErrorStatus;
 import itstime.reflog.todolist.dto.TodolistDTO;
 import itstime.reflog.todolist.service.TodolistService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "TODOLIST API", description = "투두리스트에 대한 API입니다.")
@@ -84,7 +87,35 @@ public class TodolistController {
 		return ResponseEntity.ok(CommonApiResponse.onSuccess(todolists));
 	}
 
-
+	@Operation(
+		summary = "투두리스트 수정 API",
+		description = "투두리스트 항목의 일부 정보를 수정합니다. AccessToken 필요.",
+		responses = {
+			@ApiResponse(
+				responseCode = "200",
+				description = "투두리스트 수정 성공",
+				content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+			),
+			@ApiResponse(
+				responseCode = "404",
+				description = "해당 투두리스트를 찾을 수 없음",
+				content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+			),
+			@ApiResponse(
+				responseCode = "400",
+				description = "잘못된 요청 데이터",
+				content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+			)
+		}
+	)
+	@PatchMapping("/todolist/{todolistId}")
+	public ResponseEntity<CommonApiResponse<Void>> updateTodolist(
+		@PathVariable Long todolistId,
+		@RequestBody @Valid TodolistDTO.TodolistSaveOrUpdateRequest request
+	) {
+		todolistService.updateTodolist(todolistId, request);
+		return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
+	}
 
 
 }

--- a/src/main/java/itstime/reflog/todolist/controller/TodolistController.java
+++ b/src/main/java/itstime/reflog/todolist/controller/TodolistController.java
@@ -1,0 +1,50 @@
+package itstime.reflog.todolist.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import itstime.reflog.common.CommonApiResponse;
+import itstime.reflog.common.code.ErrorReasonDTO;
+import itstime.reflog.common.code.status.ErrorStatus;
+import itstime.reflog.todolist.dto.TodolistDTO;
+import itstime.reflog.todolist.service.TodolistService;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "TODOLIST API", description = "투두리스트에 대한 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/todo")
+public class TodolistController {
+	private final TodolistService todolistService;
+
+	@Operation(
+		summary = "투두리스트 생성 API",
+		description = "새로운 투두리스트 항목을 생성합니다. AccessToken 필요.",
+		responses = {
+			@ApiResponse(
+				responseCode = "200",
+				description = "투두리스트 생성 성공"
+			),
+			@ApiResponse(
+				responseCode = "400",
+				description = "잘못된 요청 데이터"
+			),
+			@ApiResponse(
+				responseCode = "500",
+				description = "서버 에러"
+			)
+		}
+	)
+	@PostMapping("/todolist")
+	public ResponseEntity<CommonApiResponse<Void>> createTodolist(@RequestBody TodolistDTO.TodolistSaveOrUpdateRequest dto) {
+		todolistService.createTodolist(dto);
+		return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
+	}
+}

--- a/src/main/java/itstime/reflog/todolist/controller/TodolistController.java
+++ b/src/main/java/itstime/reflog/todolist/controller/TodolistController.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -90,6 +92,13 @@ public class TodolistController {
 	@Operation(
 		summary = "투두리스트 수정 API",
 		description = "투두리스트 항목의 일부 정보를 수정합니다. AccessToken 필요.",
+		parameters = {
+			@Parameter(
+				name = "todolistId",
+				description = "수정하려는 투두리스트의 고유 ID",
+				required = true
+			)
+		},
 		responses = {
 			@ApiResponse(
 				responseCode = "200",
@@ -114,6 +123,40 @@ public class TodolistController {
 		@RequestBody @Valid TodolistDTO.TodolistSaveOrUpdateRequest request
 	) {
 		todolistService.updateTodolist(todolistId, request);
+		return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
+	}
+
+	@Operation(
+		summary = "투두리스트 삭제 API",
+		description = "특정 투두리스트 항목을 삭제합니다. AccessToken 필요.",
+		parameters = {
+			@Parameter(
+				name = "todolistId",
+				description = "삭제하려는 투두리스트의 고유 ID",
+				required = true
+			)
+		},
+		responses = {
+			@ApiResponse(
+				responseCode = "200",
+				description = "투두리스트 삭제 성공",
+				content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+			),
+			@ApiResponse(
+				responseCode = "404",
+				description = "해당 투두리스트를 찾을 수 없음",
+				content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+			),
+			@ApiResponse(
+				responseCode = "500",
+				description = "서버 에러",
+				content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+			)
+		}
+	)
+	@DeleteMapping("/todolist/{todolistId}")
+	public ResponseEntity<CommonApiResponse<Void>> deleteTodolist(@PathVariable("todolistId") Long todolistId) {
+		todolistService.deleteTodolist(todolistId);
 		return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
 	}
 

--- a/src/main/java/itstime/reflog/todolist/controller/TodolistController.java
+++ b/src/main/java/itstime/reflog/todolist/controller/TodolistController.java
@@ -102,8 +102,8 @@ public class TodolistController {
 				content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
 			),
 			@ApiResponse(
-				responseCode = "400",
-				description = "잘못된 요청 데이터",
+				responseCode = "500",
+				description = "서버 에러",
 				content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
 			)
 		}

--- a/src/main/java/itstime/reflog/todolist/domain/Todolist.java
+++ b/src/main/java/itstime/reflog/todolist/domain/Todolist.java
@@ -1,0 +1,50 @@
+package itstime.reflog.todolist.domain;
+import java.time.LocalDate;
+
+import itstime.reflog.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Todolist {
+
+	@Id
+	@Column(name = "todolist_id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private String content;
+
+	@Column(nullable = false)
+	private boolean status; // 완료 여부 (기본값: false)
+
+	@Column(name = "created_date", nullable = false)
+	private LocalDate createdDate;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@PrePersist
+	protected void onCreate() {
+		this.createdDate = LocalDate.now();
+	}
+
+}

--- a/src/main/java/itstime/reflog/todolist/domain/Todolist.java
+++ b/src/main/java/itstime/reflog/todolist/domain/Todolist.java
@@ -47,4 +47,10 @@ public class Todolist {
 		this.createdDate = LocalDate.now();
 	}
 
+	public void update(String content, boolean status, Member member) {
+		this.content = content;
+		this.status = status;
+		this.member = member;
+	}
+
 }

--- a/src/main/java/itstime/reflog/todolist/dto/TodolistDTO.java
+++ b/src/main/java/itstime/reflog/todolist/dto/TodolistDTO.java
@@ -14,6 +14,9 @@ public class TodolistDTO {
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class TodolistSaveOrUpdateRequest {
 
+		@NotNull(message = "memberId는 null일 수 없습니다.")
+		private Long memberId;
+
 		@NotBlank(message = "content는 비어 있을 수 없습니다.")
 		private String content;
 

--- a/src/main/java/itstime/reflog/todolist/dto/TodolistDTO.java
+++ b/src/main/java/itstime/reflog/todolist/dto/TodolistDTO.java
@@ -1,0 +1,34 @@
+package itstime.reflog.todolist.dto;
+
+import jakarta.validation.constraints.AssertFalse;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class TodolistDTO {
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class TodolistSaveOrUpdateRequest {
+
+		@NotBlank(message = "content는 비어 있을 수 없습니다.")
+		private String content;
+
+		@NotNull(message = "status는 null일 수 없습니다.")
+		@AssertFalse(message = "status는 초기 상태에서 false여야 합니다.")
+		private boolean status;
+	}
+
+	@Getter
+	@AllArgsConstructor
+	public static class TodolistResponse {
+		private final Long todolistId;
+		private final String content;
+		private final boolean status;
+	}
+
+
+}

--- a/src/main/java/itstime/reflog/todolist/dto/TodolistDTO.java
+++ b/src/main/java/itstime/reflog/todolist/dto/TodolistDTO.java
@@ -14,9 +14,6 @@ public class TodolistDTO {
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class TodolistSaveOrUpdateRequest {
 
-		@NotNull(message = "memberId는 null일 수 없습니다.")
-		private Long memberId;
-
 		@NotBlank(message = "content는 비어 있을 수 없습니다.")
 		private String content;
 

--- a/src/main/java/itstime/reflog/todolist/dto/TodolistDTO.java
+++ b/src/main/java/itstime/reflog/todolist/dto/TodolistDTO.java
@@ -21,7 +21,6 @@ public class TodolistDTO {
 		private String content;
 
 		@NotNull(message = "status는 null일 수 없습니다.")
-		@AssertFalse(message = "status는 초기 상태에서 false여야 합니다.")
 		private boolean status;
 	}
 

--- a/src/main/java/itstime/reflog/todolist/repository/TodolistRepository.java
+++ b/src/main/java/itstime/reflog/todolist/repository/TodolistRepository.java
@@ -1,0 +1,9 @@
+package itstime.reflog.todolist.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import itstime.reflog.todolist.domain.Todolist;
+
+public interface TodolistRepository extends JpaRepository<Todolist, Integer> {
+
+}

--- a/src/main/java/itstime/reflog/todolist/repository/TodolistRepository.java
+++ b/src/main/java/itstime/reflog/todolist/repository/TodolistRepository.java
@@ -1,9 +1,14 @@
 package itstime.reflog.todolist.repository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import itstime.reflog.member.domain.Member;
 import itstime.reflog.todolist.domain.Todolist;
 
 public interface TodolistRepository extends JpaRepository<Todolist, Integer> {
 
+	List<Todolist> findByMemberAndCreatedDate(Member member, LocalDate date);
 }

--- a/src/main/java/itstime/reflog/todolist/repository/TodolistRepository.java
+++ b/src/main/java/itstime/reflog/todolist/repository/TodolistRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import itstime.reflog.member.domain.Member;
 import itstime.reflog.todolist.domain.Todolist;
 
-public interface TodolistRepository extends JpaRepository<Todolist, Integer> {
+public interface TodolistRepository extends JpaRepository<Todolist, Long> {
 
 	List<Todolist> findByMemberAndCreatedDate(Member member, LocalDate date);
 }

--- a/src/main/java/itstime/reflog/todolist/service/TodolistService.java
+++ b/src/main/java/itstime/reflog/todolist/service/TodolistService.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import itstime.reflog.common.code.status.ErrorStatus;
 import itstime.reflog.common.exception.GeneralException;
@@ -20,6 +21,7 @@ public class TodolistService {
 	private final TodolistRepository todolistRepository;
 	private final MemberRepository memberRepository;
 
+	@Transactional
 	public void createTodolist(TodolistDTO.TodolistSaveOrUpdateRequest dto) {
 		Member member = memberRepository.findById(dto.getMemberId())
 			.orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
@@ -33,6 +35,7 @@ public class TodolistService {
 		todolistRepository.save(todolist);
 	}
 
+	@Transactional(readOnly = true)
 	public List<TodolistDTO.TodolistResponse> getTodolistByMemberIdAndDate(Long memberId, LocalDate date) {
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
@@ -48,6 +51,7 @@ public class TodolistService {
 			.toList();
 	}
 
+	@Transactional
 	public void updateTodolist(Long id, TodolistDTO.TodolistSaveOrUpdateRequest request) {
 		Todolist todolist = todolistRepository.findById(id)
 			.orElseThrow(() -> new GeneralException(ErrorStatus._TODO_NOT_FOUND));
@@ -60,6 +64,7 @@ public class TodolistService {
 		todolistRepository.save(todolist);
 	}
 
+	@Transactional
 	public void deleteTodolist(Long todolistId) {
 		Todolist todolist = todolistRepository.findById(todolistId)
 			.orElseThrow(() -> new GeneralException(ErrorStatus._TODO_NOT_FOUND));

--- a/src/main/java/itstime/reflog/todolist/service/TodolistService.java
+++ b/src/main/java/itstime/reflog/todolist/service/TodolistService.java
@@ -47,4 +47,16 @@ public class TodolistService {
 			))
 			.toList();
 	}
+
+	public void updateTodolist(Long id, TodolistDTO.TodolistSaveOrUpdateRequest request) {
+		Todolist todolist = todolistRepository.findById(id)
+			.orElseThrow(() -> new GeneralException(ErrorStatus._TODO_NOT_FOUND));
+
+		Member member = memberRepository.findById(request.getMemberId())
+			.orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
+
+		todolist.update(request.getContent(), request.isStatus(), member);
+
+		todolistRepository.save(todolist);
+	}
 }

--- a/src/main/java/itstime/reflog/todolist/service/TodolistService.java
+++ b/src/main/java/itstime/reflog/todolist/service/TodolistService.java
@@ -1,5 +1,8 @@
 package itstime.reflog.todolist.service;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import itstime.reflog.common.code.status.ErrorStatus;
@@ -28,5 +31,20 @@ public class TodolistService {
 			.build();
 
 		todolistRepository.save(todolist);
+	}
+
+	public List<TodolistDTO.TodolistResponse> getTodolistByMemberIdAndDate(Long memberId, LocalDate date) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
+
+		List<Todolist> todolists = todolistRepository.findByMemberAndCreatedDate(member, date);
+
+		return todolists.stream()
+			.map(todolist -> new TodolistDTO.TodolistResponse(
+				todolist.getId(),
+				todolist.getContent(),
+				todolist.isStatus()
+			))
+			.toList();
 	}
 }

--- a/src/main/java/itstime/reflog/todolist/service/TodolistService.java
+++ b/src/main/java/itstime/reflog/todolist/service/TodolistService.java
@@ -22,8 +22,8 @@ public class TodolistService {
 	private final MemberRepository memberRepository;
 
 	@Transactional
-	public void createTodolist(TodolistDTO.TodolistSaveOrUpdateRequest dto) {
-		Member member = memberRepository.findById(dto.getMemberId())
+	public void createTodolist(Long memberId, TodolistDTO.TodolistSaveOrUpdateRequest dto) {
+		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
 
 		Todolist todolist = Todolist.builder()
@@ -52,11 +52,11 @@ public class TodolistService {
 	}
 
 	@Transactional
-	public void updateTodolist(Long id, TodolistDTO.TodolistSaveOrUpdateRequest request) {
-		Todolist todolist = todolistRepository.findById(id)
+	public void updateTodolist(Long todolistId, Long memberId, TodolistDTO.TodolistSaveOrUpdateRequest request) {
+		Todolist todolist = todolistRepository.findById(todolistId)
 			.orElseThrow(() -> new GeneralException(ErrorStatus._TODO_NOT_FOUND));
 
-		Member member = memberRepository.findById(request.getMemberId())
+		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
 
 		todolist.update(request.getContent(), request.isStatus(), member);

--- a/src/main/java/itstime/reflog/todolist/service/TodolistService.java
+++ b/src/main/java/itstime/reflog/todolist/service/TodolistService.java
@@ -1,0 +1,32 @@
+package itstime.reflog.todolist.service;
+
+import org.springframework.stereotype.Service;
+
+import itstime.reflog.common.code.status.ErrorStatus;
+import itstime.reflog.common.exception.GeneralException;
+import itstime.reflog.member.domain.Member;
+import itstime.reflog.member.repository.MemberRepository;
+import itstime.reflog.todolist.domain.Todolist;
+import itstime.reflog.todolist.dto.TodolistDTO;
+import itstime.reflog.todolist.repository.TodolistRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TodolistService {
+	private final TodolistRepository todolistRepository;
+	private final MemberRepository memberRepository;
+
+	public void createTodolist(TodolistDTO.TodolistSaveOrUpdateRequest dto) {
+		Member member = memberRepository.findById(dto.getMemberId())
+			.orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
+
+		Todolist todolist = Todolist.builder()
+			.content(dto.getContent())
+			.status(dto.isStatus())
+			.member(member)
+			.build();
+
+		todolistRepository.save(todolist);
+	}
+}

--- a/src/main/java/itstime/reflog/todolist/service/TodolistService.java
+++ b/src/main/java/itstime/reflog/todolist/service/TodolistService.java
@@ -59,4 +59,11 @@ public class TodolistService {
 
 		todolistRepository.save(todolist);
 	}
+
+	public void deleteTodolist(Long todolistId) {
+		Todolist todolist = todolistRepository.findById(todolistId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus._TODO_NOT_FOUND));
+
+		todolistRepository.delete(todolist);
+	}
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #11 

## 🔑 Key Changes

1. 내용

    - 투두리스트 API 구현 완료
    
    - 투두리스트 조회 API -> 오늘의 투두리스트 이외에 다른 날짜에 작성했던 투두리스트도 조회할 수 있는 구현했는데 이 부분은 팀장님 확인 필요
    
    - 투두리스트 생성 API -> 여기서 content랑 status를 받아오는데 status는 투두리스트 완료 유무이고 true일때 완료했음을 의미
    
    - 수정 해야 할 점: 일단 급하게 만들다 보니 코드 구현이 조금 미흡.. ㅎ, 생성 API 구현할 때 처음에 멤버 아이디가 필요없는 줄 알고 구현하다가 중간에 알아차리는 바람에 request body에 추가했음, 그러다 보니 조회 API랑 구현의 차이가 생김(조회 API는 처음부터 멤버 ID가 필요하다고 인지하고 쿼리 파라미터로 처리) 일관성을 위해 하나의 방식으로 통일하는 것이 좋겠지만 현재 정상적으로 동작하므로 수정하지 않았음. (솔직히 귀찮았습니다... 😅)
    
    - 보통 API 구현할 때 방식이 사람마다 달라서 코드 괜찮은지 코드 리뷰 부탂!

## 📸 Screenshot
![image](https://github.com/user-attachments/assets/08a0accb-6eda-4dc6-8d1f-5e4e8471b106)


