### PR TITLE
Feat : 마이페이지 API 구현

### DIFF
--- a/src/main/java/itstime/reflog/common/code/status/ErrorStatus.java
+++ b/src/main/java/itstime/reflog/common/code/status/ErrorStatus.java
@@ -23,6 +23,10 @@ public enum ErrorStatus implements BaseErrorCode {
 	_INVALID_MEMBER_CREDENTIALS(HttpStatus.UNAUTHORIZED, "MEMBER401", "잘못된 인증 정보입니다."),
 	_MEMBER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "MEMBER403", "해당 회원은 권한이 없습니다."),
 
+	// MyPage 관련 에러
+	_MYPAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "MYPAGE404", "해당 마이페이지를 찾을 수 없습니다."),
+
+
 	// TodoList 관련 에러
 	_TODO_NOT_FOUND(HttpStatus.NOT_FOUND, "TODO404", "해당 투두리스트를 찾을 수 없습니다."),
 	_TODO_UPDATE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "TODO403", "투두리스트를 수정할 권한이 없습니다."),

--- a/src/main/java/itstime/reflog/common/code/status/ErrorStatus.java
+++ b/src/main/java/itstime/reflog/common/code/status/ErrorStatus.java
@@ -26,6 +26,11 @@ public enum ErrorStatus implements BaseErrorCode {
 	// MyPage 관련 에러
 	_MYPAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "MYPAGE404", "해당 마이페이지를 찾을 수 없습니다."),
 
+	// mission 관련 에러
+	_MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "MISSION404", "해당 미션을 찾을 수 없습니다."),
+
+	// badge 관련 에러
+	_BADGE_NOT_FOUND(HttpStatus.NOT_FOUND, "BADGE404", "해당 배지를 찾을 수 없습니다."),
 
 	// TodoList 관련 에러
 	_TODO_NOT_FOUND(HttpStatus.NOT_FOUND, "TODO404", "해당 투두리스트를 찾을 수 없습니다."),

--- a/src/main/java/itstime/reflog/config/SecurityConfig.java
+++ b/src/main/java/itstime/reflog/config/SecurityConfig.java
@@ -25,7 +25,6 @@ public class SecurityConfig {
     private final OAuthLoginSuccessHandler successHandler;
     private final OAuthLoginFailureHandler oAuthLoginFailureHandler;
 //    private final CustomOAuth2UserService customOAuthService;
-    private final MemberRepository memberRepository;
 
 
     @Bean
@@ -47,7 +46,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(requests -> requests
-                        .requestMatchers("/test", "/swagger-ui/index.html", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/v3/api-docs", "/api/v1/todo/**", "/api/v1/learn/**", "/api/v1/plan/**", "/api/v1/weekly-analysis/**","/api/v1/monthly-analysis/**","/api/v1/retrospect/**").permitAll()
+                        .requestMatchers("/test", "/swagger-ui/index.html", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/v3/api-docs", "/api/v1/todo/**", "/api/v1/learn/**", "/api/v1/plan/**", "/api/v1/weekly-analysis/**","/api/v1/monthly-analysis/**","/api/v1/retrospect/**","/api/v1/mypage/**","/api/v1/notifications/**").permitAll()
                         .anyRequest().authenticated()           // 나머지 URL은 인증 필요
                 )
                 // .addFilterBefore(new TokenAuthenticationFilter(jwtTokenProvider()), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/itstime/reflog/member/domain/Member.java
+++ b/src/main/java/itstime/reflog/member/domain/Member.java
@@ -3,17 +3,10 @@ package itstime.reflog.member.domain;
 import java.util.List;
 
 import itstime.reflog.goal.domain.DailyGoal;
+import itstime.reflog.mypage.domain.MyPage;
 import itstime.reflog.schedule.domain.Schedule;
 import itstime.reflog.todolist.domain.Todolist;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -57,6 +50,9 @@ public class Member {
 
 	@OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
 	private List<Schedule> schedules;
+
+	@OneToOne(mappedBy = "member", cascade = CascadeType.ALL)
+	private MyPage myPage;
 
 	@CreationTimestamp
 	@Column(name = "created_at", nullable = false, length = 20)

--- a/src/main/java/itstime/reflog/mission/domain/Badge.java
+++ b/src/main/java/itstime/reflog/mission/domain/Badge.java
@@ -1,0 +1,26 @@
+package itstime.reflog.mission.domain;
+
+public enum Badge {
+    FIRST_MEETING(1),
+    RETROSPECTIVE_GURU(7),
+    RETROSPECTIVE_MANIA(30),
+    KING_OF_COMMUNICATION(3),
+    WEEKLY_REPORTER(2),
+    MONTHLY_REPORTER(2),
+    HABIT_STARTER(5),
+    MOTIVATION_STARTER(3),
+    POWER_OF_HEART(5),
+    RETROSPECTIVE_STARTER(1),
+    RETROSPECTIVE_REVIEWER(2),
+    POWER_OF_COMMENTS(3);
+
+    Badge(int targetNum) {
+        this.targetNum = targetNum;
+    }
+    private final int targetNum;
+
+    public int getTargetNum() {
+        return targetNum;
+    }
+}
+

--- a/src/main/java/itstime/reflog/mission/domain/UserBadge.java
+++ b/src/main/java/itstime/reflog/mission/domain/UserBadge.java
@@ -1,0 +1,33 @@
+package itstime.reflog.mission.domain;
+
+import itstime.reflog.mypage.domain.MyPage;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserBadge {
+
+    @Id
+    @Column(name = "user_badge_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private boolean isEarned;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mypage_id", nullable = false)
+    private MyPage myPage;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Badge badge;
+
+    public void setEarned(boolean b) {
+        this.isEarned = b;
+    }
+}

--- a/src/main/java/itstime/reflog/mission/domain/UserMission.java
+++ b/src/main/java/itstime/reflog/mission/domain/UserMission.java
@@ -1,0 +1,37 @@
+package itstime.reflog.mission.domain;
+
+import itstime.reflog.mypage.domain.MyPage;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserMission {
+
+    @Id
+    @Column(name = "user_mission_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private int progressCount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mypage_id", nullable = false)
+    private MyPage myPage;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Badge badge;
+
+    public void incrementProgress() {
+        this.progressCount += 1;
+    }
+
+    public boolean isCompleted() {
+        return this.progressCount >= badge.getTargetNum();
+    }
+}

--- a/src/main/java/itstime/reflog/mission/repository/UserBadgeRepository.java
+++ b/src/main/java/itstime/reflog/mission/repository/UserBadgeRepository.java
@@ -1,0 +1,14 @@
+package itstime.reflog.mission.repository;
+
+import itstime.reflog.mission.domain.Badge;
+import itstime.reflog.mission.domain.UserBadge;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserBadgeRepository extends JpaRepository<UserBadge, Long> {
+
+    Optional<UserBadge> findByMyPage_MemberIdAndBadge(Long memberId, Badge badge);
+}

--- a/src/main/java/itstime/reflog/mission/repository/UserMissionRepository.java
+++ b/src/main/java/itstime/reflog/mission/repository/UserMissionRepository.java
@@ -1,0 +1,14 @@
+package itstime.reflog.mission.repository;
+
+import itstime.reflog.mission.domain.Badge;
+import itstime.reflog.mission.domain.UserMission;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserMissionRepository extends JpaRepository<UserMission, Long> {
+
+    Optional<UserMission> findByMyPage_MemberIdAndBadge(Long memberId, Badge badge);
+}

--- a/src/main/java/itstime/reflog/mission/service/BadgeService.java
+++ b/src/main/java/itstime/reflog/mission/service/BadgeService.java
@@ -1,0 +1,33 @@
+package itstime.reflog.mission.service;
+
+import itstime.reflog.common.code.status.ErrorStatus;
+import itstime.reflog.common.exception.GeneralException;
+import itstime.reflog.mission.domain.Badge;
+import itstime.reflog.mission.domain.UserBadge;
+import itstime.reflog.mission.repository.UserBadgeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BadgeService {
+
+    private final UserBadgeRepository userBadgeRepository;
+
+    @Transactional
+    public void awardBadge(Long memberId, Badge badge) {
+        // 사용자 배지 조회
+        UserBadge userBadge = userBadgeRepository.findByMyPage_MemberIdAndBadge(memberId, badge)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._BADGE_NOT_FOUND));
+
+        // 이미 배지를 획득했으면 반환
+        if (userBadge.isEarned()) {
+            return;
+        }
+
+        // 배지 획득 처리
+        userBadge.setEarned(true);
+        userBadgeRepository.save(userBadge);
+    }
+}

--- a/src/main/java/itstime/reflog/mission/service/BadgeService.java
+++ b/src/main/java/itstime/reflog/mission/service/BadgeService.java
@@ -5,6 +5,8 @@ import itstime.reflog.common.exception.GeneralException;
 import itstime.reflog.mission.domain.Badge;
 import itstime.reflog.mission.domain.UserBadge;
 import itstime.reflog.mission.repository.UserBadgeRepository;
+import itstime.reflog.notification.domain.NotificationType;
+import itstime.reflog.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class BadgeService {
 
     private final UserBadgeRepository userBadgeRepository;
+    private final NotificationService notificationService;
 
     @Transactional
     public void awardBadge(Long memberId, Badge badge) {
@@ -29,5 +32,11 @@ public class BadgeService {
         // 배지 획득 처리
         userBadge.setEarned(true);
         userBadgeRepository.save(userBadge);
+
+        notificationService.sendNotification(
+                memberId,
+                "축하합니다! '" + badge.name() + "' 배지를 획득하셨습니다.",
+                NotificationType.MISSION
+        );
     }
 }

--- a/src/main/java/itstime/reflog/mission/service/MissionService.java
+++ b/src/main/java/itstime/reflog/mission/service/MissionService.java
@@ -1,0 +1,33 @@
+package itstime.reflog.mission.service;
+
+import itstime.reflog.common.code.status.ErrorStatus;
+import itstime.reflog.common.exception.GeneralException;
+import itstime.reflog.mission.domain.Badge;
+import itstime.reflog.mission.domain.UserMission;
+import itstime.reflog.mission.repository.UserMissionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MissionService {
+
+    private final UserMissionRepository userMissionRepository;
+    private final BadgeService badgeService;
+
+    @Transactional
+    public void incrementMissionProgress(Long memberId, Badge badge) {
+        UserMission userMission = userMissionRepository.findByMyPage_MemberIdAndBadge(memberId, badge)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._MISSION_NOT_FOUND));
+
+        // 미션 개수 증가
+        userMission.incrementProgress();
+        userMissionRepository.save(userMission);
+
+        // 미션 완료 여부 확인 및 배지 지급
+        if (userMission.isCompleted()) {
+            badgeService.awardBadge(memberId, badge);
+        }
+    }
+}

--- a/src/main/java/itstime/reflog/mypage/controller/MyPageController.java
+++ b/src/main/java/itstime/reflog/mypage/controller/MyPageController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "MYPAGE API", description = "마이페이지에 대한 API입니다.")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/plan/mypage")
+@RequestMapping("/api/v1/mypage")
 public class MyPageController {
 
     private final MyPageService myPageService;

--- a/src/main/java/itstime/reflog/mypage/controller/MyPageController.java
+++ b/src/main/java/itstime/reflog/mypage/controller/MyPageController.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import itstime.reflog.common.CommonApiResponse;
 import itstime.reflog.mypage.dto.MyPageDto;
 import itstime.reflog.mypage.service.MyPageService;
-import itstime.reflog.schedule.dto.ScheduleDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -53,11 +52,11 @@ public class MyPageController {
 
     @Operation(
             summary = "마이페이지 프로필 생성 API",
-            description = "특정 회원에 해당하는 마이페이지 프로필을 조회합니다.",
+            description = "특정 회원에 해당하는 마이페이지 프로필을 생성합니다.",
             responses = {
                     @ApiResponse(
                             responseCode = "200",
-                            description = "마이페이지 프로필 조회 성공",
+                            description = "마이페이지 프로필 생성 성공",
                             content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
                     ),
                     @ApiResponse(
@@ -108,6 +107,36 @@ public class MyPageController {
     ) {
         MyPageDto.MyPageProfileResponse profile = myPageService.getProfile(memberId);
         return ResponseEntity.ok(CommonApiResponse.onSuccess(profile));
+    }
+
+    @Operation(
+            summary = "마이페이지 프로필 수정 API",
+            description = "특정 회원에 해당하는 마이페이지 프로필을 수정합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "마이페이지 프로필 수정 성공",
+                            content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "해당 회원 또는 마이페이지 프로필을 찾을 수 없음",
+                            content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "서버 에러",
+                            content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+                    )
+            }
+    )
+    @PatchMapping("/myinfo/profile")
+    public ResponseEntity<CommonApiResponse<Void>> updateProfile(
+            @RequestParam Long memberId,
+            @Valid @RequestBody MyPageDto.MyPageProfileRequest dto
+    ) {
+        myPageService.updateProfile(memberId, dto);
+        return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
     }
 
 //    @Operation(

--- a/src/main/java/itstime/reflog/mypage/controller/MyPageController.java
+++ b/src/main/java/itstime/reflog/mypage/controller/MyPageController.java
@@ -8,6 +8,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import itstime.reflog.common.CommonApiResponse;
 import itstime.reflog.mypage.dto.MyPageDto;
 import itstime.reflog.mypage.service.MyPageService;
+import itstime.reflog.schedule.dto.ScheduleDto;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "MYPAGE API", description = "마이페이지에 대한 API입니다.")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/plan")
+@RequestMapping("/api/v1/plan/mypage")
 public class MyPageController {
 
     private final MyPageService myPageService;
@@ -41,12 +43,71 @@ public class MyPageController {
                     )
             }
     )
-    @GetMapping("/mypage")
+    @GetMapping("/myinfo")
     public ResponseEntity<CommonApiResponse<MyPageDto.MyPageInfoResponse>> getMyInformation(
             @RequestParam Long memberId
     ) {
         MyPageDto.MyPageInfoResponse myInfo = myPageService.getMyInformation(memberId);
         return ResponseEntity.ok(CommonApiResponse.onSuccess(myInfo));
+    }
+
+    @Operation(
+            summary = "마이페이지 프로필 생성 API",
+            description = "특정 회원에 해당하는 마이페이지 프로필을 조회합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "마이페이지 프로필 조회 성공",
+                            content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "해당 회원 또는 마이페이지 프로필을 찾을 수 없음",
+                            content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "서버 에러",
+                            content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+                    )
+            }
+    )
+    @PostMapping("/myinfo/profile")
+    public ResponseEntity<CommonApiResponse<Void>> createProfile(
+            @RequestParam Long memberId,
+            @Valid @RequestBody MyPageDto.MyPageProfileRequest dto
+    ) {
+        myPageService.createProfile(memberId, dto);
+        return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
+    }
+
+    @Operation(
+            summary = "마이페이지 프로필 조회 API",
+            description = "특정 회원에 해당하는 마이페이지 프로필을 조회합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "마이페이지 프로필 조회 성공",
+                            content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "해당 회원 또는 마이페이지 프로필을 찾을 수 없음",
+                            content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "서버 에러",
+                            content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+                    )
+            }
+    )
+    @GetMapping("/myinfo/profile")
+    public ResponseEntity<CommonApiResponse<MyPageDto.MyPageProfileResponse>> getProfile(
+            @RequestParam Long memberId
+    ) {
+        MyPageDto.MyPageProfileResponse profile = myPageService.getProfile(memberId);
+        return ResponseEntity.ok(CommonApiResponse.onSuccess(profile));
     }
 
 //    @Operation(
@@ -70,7 +131,7 @@ public class MyPageController {
 //                    )
 //            }
 //    )
-//    @GetMapping("/mypage")
+//    @GetMapping("/")
 //    public ResponseEntity<CommonApiResponse<MyPageDto.MyPageMissionResponse>> getMission(
 //            @RequestParam Long memberId
 //    ) {

--- a/src/main/java/itstime/reflog/mypage/controller/MyPageController.java
+++ b/src/main/java/itstime/reflog/mypage/controller/MyPageController.java
@@ -1,0 +1,80 @@
+package itstime.reflog.mypage.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import itstime.reflog.common.CommonApiResponse;
+import itstime.reflog.mypage.dto.MyPageDto;
+import itstime.reflog.mypage.service.MyPageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "MYPAGE API", description = "마이페이지에 대한 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/plan")
+public class MyPageController {
+
+    private final MyPageService myPageService;
+
+    @Operation(
+            summary = "마이페이지 내 정보 조회 API",
+            description = "특정 회원에 해당하는 마이페이지 내 정보를 조회합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "마이페이지 내 정보 조회 성공",
+                            content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "해당 회원 또는 마이페이지 내 정보를 찾을 수 없음",
+                            content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "서버 에러",
+                            content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+                    )
+            }
+    )
+    @GetMapping("/mypage")
+    public ResponseEntity<CommonApiResponse<MyPageDto.MyPageInfoResponse>> getMyInformation(
+            @RequestParam Long memberId
+    ) {
+        MyPageDto.MyPageInfoResponse myInfo = myPageService.getMyInformation(memberId);
+        return ResponseEntity.ok(CommonApiResponse.onSuccess(myInfo));
+    }
+
+//    @Operation(
+//            summary = "마이페이지 미션/배지 조회 API",
+//            description = "특정 회원에 해당하는 마이페이지 미션/배지를 조회합니다.",
+//            responses = {
+//                    @ApiResponse(
+//                            responseCode = "200",
+//                            description = "마이페이지 미션/배지 조회 성공",
+//                            content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+//                    ),
+//                    @ApiResponse(
+//                            responseCode = "404",
+//                            description = "해당 회원 또는 마이페이지 미션/배지를 찾을 수 없음",
+//                            content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+//                    ),
+//                    @ApiResponse(
+//                            responseCode = "500",
+//                            description = "서버 에러",
+//                            content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+//                    )
+//            }
+//    )
+//    @GetMapping("/mypage")
+//    public ResponseEntity<CommonApiResponse<MyPageDto.MyPageMissionResponse>> getMission(
+//            @RequestParam Long memberId
+//    ) {
+//        MyPageDto.MyPageMissionResponse mission = myPageService.getMission(memberId);
+//        return ResponseEntity.ok(CommonApiResponse.onSuccess(mission));
+//    }
+}

--- a/src/main/java/itstime/reflog/mypage/domain/MyPage.java
+++ b/src/main/java/itstime/reflog/mypage/domain/MyPage.java
@@ -1,6 +1,7 @@
 package itstime.reflog.mypage.domain;
 
 import itstime.reflog.member.domain.Member;
+import itstime.reflog.mypage.dto.MyPageDto;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -25,4 +26,10 @@ public class MyPage {
     @OneToOne
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    public void update(MyPageDto.MyPageProfileRequest dto, Member member) {
+        this.nickname = dto.getNickname();
+        this.email = dto.getEmail();
+        this.member = member;
+    }
 }

--- a/src/main/java/itstime/reflog/mypage/domain/MyPage.java
+++ b/src/main/java/itstime/reflog/mypage/domain/MyPage.java
@@ -1,0 +1,28 @@
+package itstime.reflog.mypage.domain;
+
+import itstime.reflog.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MyPage {
+
+    @Id
+    @Column(name = "mypage_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
+    private String email;
+
+    @OneToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+}

--- a/src/main/java/itstime/reflog/mypage/domain/MyPage.java
+++ b/src/main/java/itstime/reflog/mypage/domain/MyPage.java
@@ -1,9 +1,13 @@
 package itstime.reflog.mypage.domain;
 
 import itstime.reflog.member.domain.Member;
+import itstime.reflog.mission.domain.UserBadge;
+import itstime.reflog.mission.domain.UserMission;
 import itstime.reflog.mypage.dto.MyPageDto;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.List;
 
 @Entity
 @Getter
@@ -22,6 +26,12 @@ public class MyPage {
 
     @Column(nullable = false)
     private String email;
+
+    @OneToMany(mappedBy = "myPage", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UserBadge> userBadges;
+
+    @OneToMany(mappedBy = "myPage", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UserMission> userMissions;
 
     @OneToOne
     @JoinColumn(name = "member_id", nullable = false)

--- a/src/main/java/itstime/reflog/mypage/dto/MyPageDto.java
+++ b/src/main/java/itstime/reflog/mypage/dto/MyPageDto.java
@@ -1,5 +1,8 @@
 package itstime.reflog.mypage.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,8 +11,27 @@ public class MyPageDto {
     @Getter
     @AllArgsConstructor
     public static class MyPageInfoResponse {
-        private final String name;
+        private final String nickname;
     }
+
+    @Getter
+    @AllArgsConstructor
+    public static class MyPageProfileRequest {
+        @Size(min = 2, max = 20, message = "이름은 2~20글자로 한글, 영문, 숫자, 특수기호(,)(-)만 사용할 수 있습니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9.-]+$", message = "이름은 2~20글자로 한글, 영문, 숫자, 특수기호(,)(-)만 사용할 수 있습니다.")
+        private String nickname;
+
+        @Email(message = "이메일 정보가 올바르지 않습니다.")
+        private String email;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class MyPageProfileResponse {
+        private String nickname;
+        private String email;
+    }
+
 
     @Getter
     @AllArgsConstructor

--- a/src/main/java/itstime/reflog/mypage/dto/MyPageDto.java
+++ b/src/main/java/itstime/reflog/mypage/dto/MyPageDto.java
@@ -1,0 +1,19 @@
+package itstime.reflog.mypage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class MyPageDto {
+
+    @Getter
+    @AllArgsConstructor
+    public static class MyPageInfoResponse {
+        private final String name;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class MyPageMissionResponse {
+
+    }
+}

--- a/src/main/java/itstime/reflog/mypage/dto/MyPageDto.java
+++ b/src/main/java/itstime/reflog/mypage/dto/MyPageDto.java
@@ -31,11 +31,4 @@ public class MyPageDto {
         private String nickname;
         private String email;
     }
-
-
-    @Getter
-    @AllArgsConstructor
-    public static class MyPageMissionResponse {
-
-    }
 }

--- a/src/main/java/itstime/reflog/mypage/dto/MyPageDto.java
+++ b/src/main/java/itstime/reflog/mypage/dto/MyPageDto.java
@@ -11,7 +11,7 @@ public class MyPageDto {
     @Getter
     @AllArgsConstructor
     public static class MyPageInfoResponse {
-        private final String nickname;
+        private String nickname;
     }
 
     @Getter

--- a/src/main/java/itstime/reflog/mypage/repository/MyPageRepository.java
+++ b/src/main/java/itstime/reflog/mypage/repository/MyPageRepository.java
@@ -3,8 +3,11 @@ package itstime.reflog.mypage.repository;
 import itstime.reflog.member.domain.Member;
 import itstime.reflog.mypage.domain.MyPage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
+@Repository
 public interface MyPageRepository extends JpaRepository<MyPage, Long> {
-    boolean existsByMember(Member member);
-
+    Optional<MyPage> findByMember(Member member);
 }

--- a/src/main/java/itstime/reflog/mypage/repository/MyPageRepository.java
+++ b/src/main/java/itstime/reflog/mypage/repository/MyPageRepository.java
@@ -1,0 +1,10 @@
+package itstime.reflog.mypage.repository;
+
+import itstime.reflog.member.domain.Member;
+import itstime.reflog.mypage.domain.MyPage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MyPageRepository extends JpaRepository<MyPage, Long> {
+    boolean existsByMember(Member member);
+
+}

--- a/src/main/java/itstime/reflog/mypage/service/InitializationService.java
+++ b/src/main/java/itstime/reflog/mypage/service/InitializationService.java
@@ -1,0 +1,45 @@
+package itstime.reflog.mypage.service;
+
+import itstime.reflog.mission.domain.Badge;
+import itstime.reflog.mission.domain.UserBadge;
+import itstime.reflog.mission.domain.UserMission;
+import itstime.reflog.mission.repository.UserBadgeRepository;
+import itstime.reflog.mission.repository.UserMissionRepository;
+import itstime.reflog.mypage.domain.MyPage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class InitializationService {
+
+    private final UserBadgeRepository userBadgeRepository;
+    private final UserMissionRepository userMissionRepository;
+
+
+    @Transactional
+    public void initializeForNewMember(MyPage myPage) {
+
+        List<UserBadge> userBadges = Arrays.stream(Badge.values())
+                .map(badge -> UserBadge.builder()
+                        .myPage(myPage)
+                        .badge(badge)
+                        .isEarned(false)
+                        .build())
+                .toList();
+        userBadgeRepository.saveAll(userBadges);
+
+        List<UserMission> userMissions = Arrays.stream(Badge.values())
+                .map(badge -> UserMission.builder()
+                        .myPage(myPage)
+                        .badge(badge)
+                        .progressCount(0)
+                        .build())
+                .toList();
+        userMissionRepository.saveAll(userMissions);
+    }
+}

--- a/src/main/java/itstime/reflog/mypage/service/MyPageService.java
+++ b/src/main/java/itstime/reflog/mypage/service/MyPageService.java
@@ -23,8 +23,11 @@ public class MyPageService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
 
+        MyPage myPage = myPageRepository.findByMember(member)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._MYPAGE_NOT_FOUND));
+
         return new MyPageDto.MyPageInfoResponse(
-                member.getName()
+                myPage.getNickname()
         );
     }
 

--- a/src/main/java/itstime/reflog/mypage/service/MyPageService.java
+++ b/src/main/java/itstime/reflog/mypage/service/MyPageService.java
@@ -4,6 +4,7 @@ import itstime.reflog.common.code.status.ErrorStatus;
 import itstime.reflog.common.exception.GeneralException;
 import itstime.reflog.member.domain.Member;
 import itstime.reflog.member.repository.MemberRepository;
+import itstime.reflog.mission.service.MissionService;
 import itstime.reflog.mypage.domain.MyPage;
 import itstime.reflog.mypage.dto.MyPageDto;
 import itstime.reflog.mypage.repository.MyPageRepository;
@@ -11,12 +12,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static itstime.reflog.mission.domain.Badge.FIRST_MEETING;
+
 @Service
 @RequiredArgsConstructor
 public class MyPageService {
 
     private final MyPageRepository myPageRepository;
     private final MemberRepository memberRepository;
+    private final InitializationService initializationService;
+    private final MissionService missionService;
 
     @Transactional
     public MyPageDto.MyPageInfoResponse getMyInformation(Long memberId) {
@@ -43,6 +48,11 @@ public class MyPageService {
                 .build();
 
         myPageRepository.save(myPage);
+        myPageRepository.flush();
+
+        initializationService.initializeForNewMember(myPage);
+
+        missionService.incrementMissionProgress(memberId, FIRST_MEETING);
     }
 
     @Transactional

--- a/src/main/java/itstime/reflog/mypage/service/MyPageService.java
+++ b/src/main/java/itstime/reflog/mypage/service/MyPageService.java
@@ -1,0 +1,33 @@
+package itstime.reflog.mypage.service;
+
+import itstime.reflog.common.code.status.ErrorStatus;
+import itstime.reflog.common.exception.GeneralException;
+import itstime.reflog.member.domain.Member;
+import itstime.reflog.member.repository.MemberRepository;
+import itstime.reflog.mypage.dto.MyPageDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public MyPageDto.MyPageInfoResponse getMyInformation(Long memberId) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
+
+        return new MyPageDto.MyPageInfoResponse(
+                member.getName()
+        );
+    }
+
+//    @Transactional
+//    public MyPageDto.MyPageMissionResponse getMission(Long memberId) {
+//
+//    }
+}

--- a/src/main/java/itstime/reflog/mypage/service/MyPageService.java
+++ b/src/main/java/itstime/reflog/mypage/service/MyPageService.java
@@ -4,7 +4,10 @@ import itstime.reflog.common.code.status.ErrorStatus;
 import itstime.reflog.common.exception.GeneralException;
 import itstime.reflog.member.domain.Member;
 import itstime.reflog.member.repository.MemberRepository;
+import itstime.reflog.mypage.domain.MyPage;
 import itstime.reflog.mypage.dto.MyPageDto;
+import itstime.reflog.mypage.repository.MyPageRepository;
+import itstime.reflog.schedule.domain.Schedule;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,11 +16,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MyPageService {
 
+    private final MyPageRepository myPageRepository;
     private final MemberRepository memberRepository;
 
     @Transactional
     public MyPageDto.MyPageInfoResponse getMyInformation(Long memberId) {
-
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
 
@@ -26,8 +29,31 @@ public class MyPageService {
         );
     }
 
-//    @Transactional
-//    public MyPageDto.MyPageMissionResponse getMission(Long memberId) {
-//
-//    }
+    @Transactional
+    public void createProfile(Long memberId, MyPageDto.MyPageProfileRequest dto) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
+
+        MyPage myPage = MyPage.builder()
+                .nickname(dto.getNickname())
+                .email(dto.getEmail())
+                .member(member)
+                .build();
+
+        myPageRepository.save(myPage);
+    }
+
+    @Transactional
+    public MyPageDto.MyPageProfileResponse getProfile(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
+
+        MyPage myPage = myPageRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._MYPAGE_NOT_FOUND));
+
+        return new MyPageDto.MyPageProfileResponse(
+                myPage.getNickname(),
+                myPage.getEmail()
+        );
+    }
 }

--- a/src/main/java/itstime/reflog/mypage/service/MyPageService.java
+++ b/src/main/java/itstime/reflog/mypage/service/MyPageService.java
@@ -7,7 +7,6 @@ import itstime.reflog.member.repository.MemberRepository;
 import itstime.reflog.mypage.domain.MyPage;
 import itstime.reflog.mypage.dto.MyPageDto;
 import itstime.reflog.mypage.repository.MyPageRepository;
-import itstime.reflog.schedule.domain.Schedule;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,12 +47,25 @@ public class MyPageService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
 
-        MyPage myPage = myPageRepository.findById(memberId)
+        MyPage myPage = myPageRepository.findByMember(member)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._MYPAGE_NOT_FOUND));
 
         return new MyPageDto.MyPageProfileResponse(
                 myPage.getNickname(),
                 myPage.getEmail()
         );
+    }
+
+    @Transactional
+    public void updateProfile(Long memberId, MyPageDto.MyPageProfileRequest dto) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
+
+        MyPage myPage = myPageRepository.findByMember(member)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._MYPAGE_NOT_FOUND));
+
+        myPage.update(dto, member);
+
+        myPageRepository.save(myPage);
     }
 }

--- a/src/main/java/itstime/reflog/notification/controller/NotificationController.java
+++ b/src/main/java/itstime/reflog/notification/controller/NotificationController.java
@@ -1,0 +1,24 @@
+package itstime.reflog.notification.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import itstime.reflog.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Tag(name = "NOTIFICATION API", description = "알림에 대한 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping("/subscribe/{memberId}")
+    public SseEmitter subscribe(@PathVariable Long memberId) {
+        return notificationService.subscribe(memberId);
+    }
+}

--- a/src/main/java/itstime/reflog/notification/domain/Notification.java
+++ b/src/main/java/itstime/reflog/notification/domain/Notification.java
@@ -1,0 +1,32 @@
+package itstime.reflog.notification.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Notification {
+
+    @Id
+    @Column(name = "notification_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType type;
+
+    @Column(nullable = false)
+    private String message;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private Long memberId;
+}

--- a/src/main/java/itstime/reflog/notification/domain/NotificationType.java
+++ b/src/main/java/itstime/reflog/notification/domain/NotificationType.java
@@ -1,0 +1,7 @@
+package itstime.reflog.notification.domain;
+
+public enum NotificationType {
+    MISSION,
+    POST,
+    COMMENT
+}

--- a/src/main/java/itstime/reflog/notification/repository/NotificationRepository.java
+++ b/src/main/java/itstime/reflog/notification/repository/NotificationRepository.java
@@ -1,0 +1,11 @@
+package itstime.reflog.notification.repository;
+
+import itstime.reflog.notification.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> findByMemberId(Long memberId);
+}

--- a/src/main/java/itstime/reflog/notification/service/NotificationService.java
+++ b/src/main/java/itstime/reflog/notification/service/NotificationService.java
@@ -1,0 +1,53 @@
+package itstime.reflog.notification.service;
+
+import itstime.reflog.notification.domain.Notification;
+import itstime.reflog.notification.domain.NotificationType;
+import itstime.reflog.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter subscribe(Long memberId) {
+        SseEmitter emitter = new SseEmitter(60 * 1000L); // 60 seconds timeout
+        emitters.put(memberId, emitter);
+
+        // Remove emitter on completion, timeout, or error
+        emitter.onCompletion(() -> emitters.remove(memberId));
+        emitter.onTimeout(() -> emitters.remove(memberId));
+        emitter.onError(e -> emitters.remove(memberId));
+
+        return emitter;
+    }
+
+    public void sendNotification(Long memberId, String message, NotificationType type) {
+        // Save the notification to the database
+        Notification notification = Notification.builder()
+                .memberId(memberId)
+                .message(message)
+                .type(type)
+                .createdAt(LocalDateTime.now())
+                .build();
+        notificationRepository.save(notification);
+
+        // Send the notification via SSE if the user is connected
+        SseEmitter emitter = emitters.get(memberId);
+        if (emitter != null) {
+            try {
+                emitter.send(SseEmitter.event().name("notification").data(message));
+            } catch (Exception e) {
+                emitters.remove(memberId); // Remove emitter on failure
+            }
+        }
+    }
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #26 

## 🔑 Key Changes

1. 내용
    - 마이페이지 API 구현 (커뮤니티 제외)
    - 미션/배지 부분이 복잡해서 따로 패키지를 파서 구현
    - 미션/배지 부분은 badge를 enum으로 해서 userBadge와 userMission으로 분리해서 실시간 상황 저장함
    - 알람 파트도 미션/배지 부분은 sse 실시간 알림으로 구현해서 db에 저장하는 거 확인함
    
    - 커뮤니티 부분은 아직 안함



## 📸 Screenshot

