### PR TITLE
Feat: 커뮤니티 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'

--- a/src/main/java/itstime/reflog/common/code/status/ErrorStatus.java
+++ b/src/main/java/itstime/reflog/common/code/status/ErrorStatus.java
@@ -45,7 +45,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
 	//S3 관련 에러
 	_S3_FILE_OPERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3_FILE_500", "S3 파일 작업 중 오류가 발생했습니다."),
-	_S3_INVALID_URL(HttpStatus.BAD_REQUEST, "S3_FILE_400", "S3 파일 URL이 잘못되었거나 존재하지 않습니다.");
+	_S3_INVALID_URL(HttpStatus.BAD_REQUEST, "S3_FILE_400", "S3 파일 URL이 잘못되었거나 존재하지 않습니다."),
+
+	// Community 관련 에러
+	_COMMUNITY_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMUNITY404", "해당 커뮤니티 게시글을 찾을 수 없습니다.");
 
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/itstime/reflog/common/code/status/ErrorStatus.java
+++ b/src/main/java/itstime/reflog/common/code/status/ErrorStatus.java
@@ -42,7 +42,11 @@ public enum ErrorStatus implements BaseErrorCode {
 	//Analysis 관련 에러
 	_ANALYSIS_NOT_FOUND(HttpStatus.NOT_FOUND, "ANALYSIS404", "분석보고서를 찾을 수 없습니다."),
 	_ANALYSIS_NOT_ALREADY(HttpStatus.NOT_FOUND, "ANALYSIS400", "아직 분석보고서가 생성되지 않았습니다."),
-	;
+
+	//S3 관련 에러
+	_S3_FILE_OPERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3_FILE_500", "S3 파일 작업 중 오류가 발생했습니다."),
+	_S3_INVALID_URL(HttpStatus.BAD_REQUEST, "S3_FILE_400", "S3 파일 URL이 잘못되었거나 존재하지 않습니다.");
+
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/itstime/reflog/community/controller/CommunityController.java
+++ b/src/main/java/itstime/reflog/community/controller/CommunityController.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -14,6 +15,7 @@ import org.springframework.web.multipart.MultipartFile;
 import itstime.reflog.common.CommonApiResponse;
 import itstime.reflog.community.service.CommunityService;
 import itstime.reflog.s3.AmazonS3Manager;
+import itstime.reflog.community.dto.CommunityDto;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -31,5 +33,13 @@ public class CommunityController {
 
 		// URL 반환
 		return ResponseEntity.ok(CommonApiResponse.onSuccess(fileUrl));
+	}
+
+	@PostMapping
+	public ResponseEntity<CommonApiResponse<Void>> createCommunity(
+		@RequestParam Long memberId,
+		@RequestBody CommunityDto.CommunitySaveOrUpdateRequest dto) {
+		communityService.createCommunity(memberId, dto);
+		return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
 	}
 }

--- a/src/main/java/itstime/reflog/community/controller/CommunityController.java
+++ b/src/main/java/itstime/reflog/community/controller/CommunityController.java
@@ -1,0 +1,35 @@
+package itstime.reflog.community.controller;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import itstime.reflog.common.CommonApiResponse;
+import itstime.reflog.community.service.CommunityService;
+import itstime.reflog.s3.AmazonS3Manager;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/communities")
+public class CommunityController {
+	private final CommunityService communityService;
+	private final AmazonS3Manager amazonS3Manager;
+
+	@PostMapping(value = "/temp-files", consumes = "multipart/form-data")
+	public ResponseEntity<CommonApiResponse<String>> uploadTempFile(
+		@RequestPart MultipartFile file) {
+		// S3에 임시 저장
+		String fileUrl = amazonS3Manager.uploadFile("temporary/" + UUID.randomUUID(), file);
+
+		// URL 반환
+		return ResponseEntity.ok(CommonApiResponse.onSuccess(fileUrl));
+	}
+}

--- a/src/main/java/itstime/reflog/community/controller/CommunityController.java
+++ b/src/main/java/itstime/reflog/community/controller/CommunityController.java
@@ -15,12 +15,16 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import itstime.reflog.common.CommonApiResponse;
 import itstime.reflog.community.service.CommunityService;
 import itstime.reflog.s3.AmazonS3Manager;
 import itstime.reflog.community.dto.CommunityDto;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "COMMUNITY API", description = "커뮤니티에 대한 API입니다.")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/communities")
@@ -28,6 +32,20 @@ public class CommunityController {
 	private final CommunityService communityService;
 	private final AmazonS3Manager amazonS3Manager;
 
+	@Operation(
+		summary = "커뮤니티 파일 임시 생성 API",
+		description = "커뮤니티 게시글 작성 시에 등록 전에도 사진이 보여져야 하기 때문에 파일 임시 생성 API를 만들었습니다. 만약 게시글 작성할 때 파일을 업로드하게 된다면 이 API를 사용해주세요. AccessToken 필요.",
+		responses = {
+			@ApiResponse(
+				responseCode = "200",
+				description = "커뮤니티 파일 임시 생성 성공"
+			),
+			@ApiResponse(
+				responseCode = "500",
+				description = "서버 에러"
+			)
+		}
+	)
 	@PostMapping(value = "/temp-files", consumes = "multipart/form-data")
 	public ResponseEntity<CommonApiResponse<String>> uploadTempFile(
 		@RequestPart MultipartFile file) {
@@ -38,6 +56,24 @@ public class CommunityController {
 		return ResponseEntity.ok(CommonApiResponse.onSuccess(fileUrl));
 	}
 
+	@Operation(
+		summary = "커뮤니티 생성 API",
+		description = "커뮤니티 게시글 생성 API입니다. 게시글 등록할 때 파일을 업로드하게 되면 커뮤니티 파일 임시 생성 API에서 받은 url값을 fileUrls에 전달해주시면 돼요. AccessToken 필요.",
+		responses = {
+			@ApiResponse(
+				responseCode = "200",
+				description = "커뮤니티 게시글 생성 성공"
+			),
+			@ApiResponse(
+				responseCode = "404",
+				description = "해당 회원을 찾을 수 없음"
+			),
+			@ApiResponse(
+				responseCode = "500",
+				description = "서버 에러"
+			)
+		}
+	)
 	@PostMapping
 	public ResponseEntity<CommonApiResponse<Void>> createCommunity(
 		@RequestParam Long memberId,
@@ -46,6 +82,24 @@ public class CommunityController {
 		return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
 	}
 
+	@Operation(
+		summary = "커뮤니티 수정 API",
+		description = "커뮤니티 게시글 수정 API입니다. 마찬가지로 게시글 수정할 때 파일을 업로드하게 되면 커뮤니티 파일 임시 생성 API에서 받은 url값을 fileUrls에 전달해주시면 돼요. AccessToken 필요.",
+		responses = {
+			@ApiResponse(
+				responseCode = "200",
+				description = "커뮤니티 게시글 수정 성공"
+			),
+			@ApiResponse(
+				responseCode = "400",
+				description = "S3 파일 URL이 잘못되었거나 존재X"
+			),
+			@ApiResponse(
+				responseCode = "500",
+				description = "서버 에러"
+			)
+		}
+	)
 	@PatchMapping
 	public ResponseEntity<CommonApiResponse<Void>> updateCommunity(
 		@RequestParam Long communityId,
@@ -54,6 +108,24 @@ public class CommunityController {
 		return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
 	}
 
+	@Operation(
+		summary = "커뮤니티 삭제 API",
+		description = "커뮤니티 게시글 삭제 API입니다. AccessToken 필요.",
+		responses = {
+			@ApiResponse(
+				responseCode = "200",
+				description = "커뮤니티 게시글 삭제 성공"
+			),
+			@ApiResponse(
+				responseCode = "404",
+				description = "해당 회원을 찾을 수 없음"
+			),
+			@ApiResponse(
+				responseCode = "500",
+				description = "서버 에러"
+			)
+		}
+	)
 	@DeleteMapping
 	public ResponseEntity<CommonApiResponse<Void>> deleteCommunity(
 		@RequestParam Long communityId) {

--- a/src/main/java/itstime/reflog/community/controller/CommunityController.java
+++ b/src/main/java/itstime/reflog/community/controller/CommunityController.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,4 +44,14 @@ public class CommunityController {
 		communityService.createCommunity(memberId, dto);
 		return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
 	}
+
+	@PatchMapping
+	public ResponseEntity<CommonApiResponse<Void>> updateCommunity(
+		@RequestParam Long communityId,
+		@RequestBody CommunityDto.CommunitySaveOrUpdateRequest dto) {
+		communityService.updateCommunity(communityId, dto);
+		return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
+	}
+
+
 }

--- a/src/main/java/itstime/reflog/community/controller/CommunityController.java
+++ b/src/main/java/itstime/reflog/community/controller/CommunityController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -50,6 +51,13 @@ public class CommunityController {
 		@RequestParam Long communityId,
 		@RequestBody CommunityDto.CommunitySaveOrUpdateRequest dto) {
 		communityService.updateCommunity(communityId, dto);
+		return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
+	}
+
+	@DeleteMapping
+	public ResponseEntity<CommonApiResponse<Void>> deleteCommunity(
+		@RequestParam Long communityId) {
+		communityService.deleteCommunity(communityId);
 		return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
 	}
 

--- a/src/main/java/itstime/reflog/community/domain/Community.java
+++ b/src/main/java/itstime/reflog/community/domain/Community.java
@@ -56,4 +56,12 @@ public class Community {
 
 	private LocalDateTime createdAt; // 생성일
 	private LocalDateTime updatedAt; // 수정일
+
+	public void update(String title, String content, List<String> postTypes, List<String> learningTypes) {
+		this.title = title;
+		this.content = content;
+		this.postTypes = postTypes;
+		this.learningTypes = learningTypes;
+		this.updatedAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/itstime/reflog/community/domain/Community.java
+++ b/src/main/java/itstime/reflog/community/domain/Community.java
@@ -1,0 +1,52 @@
+package itstime.reflog.community.domain;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Community {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String title; // 제목
+
+	private String content; // 게시글 내용
+
+	@ElementCollection
+	@CollectionTable(name = "community_post_types", joinColumns = @JoinColumn(name = "community_id"))
+	@Column(name = "post_type")
+	private List<String> postTypes; // 글 유형 (최대 2개)
+
+	@ElementCollection
+	@CollectionTable(name = "community_learning_types", joinColumns = @JoinColumn(name = "community_id"))
+	@Column(name = "learning_type")
+	private List<String> learningTypes; // 학습 유형 (최대 2개)
+
+	@OneToMany(mappedBy = "community", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<UploadedFile> uploadedFiles; // 업로드된 파일들 (PDF 및 이미지)
+
+	private LocalDateTime createdAt; // 생성일
+	private LocalDateTime updatedAt; // 수정일
+}

--- a/src/main/java/itstime/reflog/community/domain/Community.java
+++ b/src/main/java/itstime/reflog/community/domain/Community.java
@@ -3,16 +3,19 @@ package itstime.reflog.community.domain;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import itstime.reflog.member.domain.Member;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -46,6 +49,10 @@ public class Community {
 
 	@OneToMany(mappedBy = "community", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<UploadedFile> uploadedFiles; // 업로드된 파일들 (PDF 및 이미지)
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
 
 	private LocalDateTime createdAt; // 생성일
 	private LocalDateTime updatedAt; // 수정일

--- a/src/main/java/itstime/reflog/community/domain/UploadedFile.java
+++ b/src/main/java/itstime/reflog/community/domain/UploadedFile.java
@@ -23,7 +23,6 @@ public class UploadedFile {
 	private Long id;
 
 	private String fileName; // 원본 파일 이름
-	private String fileType; // 파일 유형 (예: PDF, IMAGE)
 	private String fileUrl;  // S3 URL
 
 	@ManyToOne

--- a/src/main/java/itstime/reflog/community/domain/UploadedFile.java
+++ b/src/main/java/itstime/reflog/community/domain/UploadedFile.java
@@ -1,0 +1,33 @@
+package itstime.reflog.community.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UploadedFile {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String fileName; // 원본 파일 이름
+	private String fileType; // 파일 유형 (예: PDF, IMAGE)
+	private String fileUrl;  // S3 URL
+
+	@ManyToOne
+	@JoinColumn(name = "community_id")
+	private Community community; // 해당 게시글
+
+}

--- a/src/main/java/itstime/reflog/community/dto/CommunityDto.java
+++ b/src/main/java/itstime/reflog/community/dto/CommunityDto.java
@@ -1,0 +1,20 @@
+package itstime.reflog.community.dto;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class CommunityDto {
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class CommunitySaveOrUpdateRequest {
+		private String title;
+		private String content;
+		private List<String> postTypes;
+		private List<String> learningTypes;
+		private List<String> fileUrls;
+	}
+}

--- a/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
+++ b/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
@@ -1,0 +1,8 @@
+package itstime.reflog.community.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import itstime.reflog.community.domain.Community;
+
+public interface CommunityRepository extends JpaRepository<Community, Long> {
+}

--- a/src/main/java/itstime/reflog/community/repository/UploadedFileRepository.java
+++ b/src/main/java/itstime/reflog/community/repository/UploadedFileRepository.java
@@ -1,8 +1,11 @@
 package itstime.reflog.community.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import itstime.reflog.community.domain.UploadedFile;
 
 public interface UploadedFileRepository extends JpaRepository<UploadedFile, Long> {
+	List<UploadedFile> findByCommunityId(Long communityId);
 }

--- a/src/main/java/itstime/reflog/community/repository/UploadedFileRepository.java
+++ b/src/main/java/itstime/reflog/community/repository/UploadedFileRepository.java
@@ -1,0 +1,8 @@
+package itstime.reflog.community.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import itstime.reflog.community.domain.UploadedFile;
+
+public interface UploadedFileRepository extends JpaRepository<UploadedFile, Long> {
+}

--- a/src/main/java/itstime/reflog/community/service/CommunityService.java
+++ b/src/main/java/itstime/reflog/community/service/CommunityService.java
@@ -1,0 +1,59 @@
+package itstime.reflog.community.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import itstime.reflog.common.code.status.ErrorStatus;
+import itstime.reflog.common.exception.GeneralException;
+import itstime.reflog.community.domain.Community;
+import itstime.reflog.community.domain.UploadedFile;
+import itstime.reflog.community.dto.CommunityDto;
+import itstime.reflog.community.repository.CommunityRepository;
+import itstime.reflog.community.repository.UploadedFileRepository;
+import itstime.reflog.member.domain.Member;
+import itstime.reflog.member.repository.MemberRepository;
+import itstime.reflog.s3.AmazonS3Manager;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CommunityService {
+	private final CommunityRepository communityRepository;
+	private final UploadedFileRepository uploadedFileRepository;
+	private final AmazonS3Manager amazonS3Manager;
+	private final MemberRepository memberRepository;
+
+	@Transactional
+	public void createCommunity(Long memberId, CommunityDto.CommunitySaveOrUpdateRequest dto) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
+
+		Community community = Community.builder()
+			.title(dto.getTitle())
+			.content(dto.getContent())
+			.postTypes(dto.getPostTypes())
+			.learningTypes(dto.getLearningTypes())
+			.member(member)
+			.createdAt(LocalDateTime.now())
+			.build();
+
+		Community savedCommunity = communityRepository.save(community);
+
+		dto.getFileUrls().forEach(tempUrl -> {
+			String fileKey = amazonS3Manager.extractFileKeyFromUrl(tempUrl);
+
+			String newKey = fileKey.replace("temporary/", "community/");
+
+			amazonS3Manager.moveFile(fileKey, newKey);
+
+			UploadedFile uploadedFile = UploadedFile.builder()
+				.fileName(newKey.substring(newKey.lastIndexOf("/") + 1))
+				.fileUrl(amazonS3Manager.getFileUrl(newKey))
+				.community(savedCommunity)
+				.build();
+			uploadedFileRepository.save(uploadedFile);
+		});
+	}
+}

--- a/src/main/java/itstime/reflog/config/AmazonConfig.java
+++ b/src/main/java/itstime/reflog/config/AmazonConfig.java
@@ -1,0 +1,49 @@
+package itstime.reflog.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+
+@Configuration
+@Getter
+public class AmazonConfig {
+	private AWSCredentials awsCredentials;
+
+	@Value("${cloud.aws.credentials.accessKey}")
+	private String accesskey;
+
+	@Value("${cloud.aws.credentials.secretKey}")
+	private String secretkey;
+
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+
+
+	@PostConstruct
+	public void init(){ this.awsCredentials = new BasicAWSCredentials(accesskey, secretkey); }
+
+	@Bean
+	public AmazonS3 s3Client(){
+		AWSCredentials awsCredentials1 = new BasicAWSCredentials(accesskey, secretkey);
+		return AmazonS3ClientBuilder.standard()
+			.withRegion(region)
+			.withCredentials(new AWSStaticCredentialsProvider(awsCredentials1))
+			.build();
+	}
+
+	@Bean
+	public AWSCredentialsProvider awsCredentialsProvider(){ return new AWSStaticCredentialsProvider(awsCredentials); }
+}

--- a/src/main/java/itstime/reflog/member/domain/Member.java
+++ b/src/main/java/itstime/reflog/member/domain/Member.java
@@ -2,6 +2,7 @@ package itstime.reflog.member.domain;
 
 import java.util.List;
 
+import itstime.reflog.community.domain.Community;
 import itstime.reflog.goal.domain.DailyGoal;
 import itstime.reflog.schedule.domain.Schedule;
 import itstime.reflog.todolist.domain.Todolist;
@@ -57,6 +58,9 @@ public class Member {
 
 	@OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
 	private List<Schedule> schedules;
+
+	@OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+	private List<Community> communities;
 
 	@CreationTimestamp
 	@Column(name = "created_at", nullable = false, length = 20)

--- a/src/main/java/itstime/reflog/s3/AmazonS3Manager.java
+++ b/src/main/java/itstime/reflog/s3/AmazonS3Manager.java
@@ -1,0 +1,48 @@
+package itstime.reflog.s3;
+
+import java.io.IOException;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+
+import itstime.reflog.config.AmazonConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AmazonS3Manager {
+	private final AmazonS3 amazonS3;
+
+	private final AmazonConfig amazonConfig;
+
+	public String uploadFile(String keyName, MultipartFile file){
+		ObjectMetadata metadata = new ObjectMetadata();
+		metadata.setContentType(file.getContentType());
+		metadata.setContentLength(file.getSize());
+		try{
+			amazonS3.putObject(new PutObjectRequest(amazonConfig.getBucket(),keyName,file.getInputStream(), metadata));
+		}catch (IOException e){
+			log.error("error at AmazonS3Manager uploadFile : {}",(Object) e.getStackTrace());
+		}
+		return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
+	}
+
+	public void deleteImage(String fileUrl){
+		try{
+			String splitStr = ".com/";
+			String fileName = fileUrl.substring(fileUrl.lastIndexOf(splitStr) + splitStr.length());
+			amazonS3.deleteObject(new DeleteObjectRequest(amazonConfig.getBucket(), fileName));
+		}
+		catch(SdkClientException e){
+			log.error("Error deleting file from s3");
+		}
+	}
+}

--- a/src/main/java/itstime/reflog/s3/AmazonS3Manager.java
+++ b/src/main/java/itstime/reflog/s3/AmazonS3Manager.java
@@ -20,7 +20,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class AmazonS3Manager {
 	private final AmazonS3 amazonS3;
-
 	private final AmazonConfig amazonConfig;
 
 	public String uploadFile(String keyName, MultipartFile file){
@@ -44,5 +43,23 @@ public class AmazonS3Manager {
 		catch(SdkClientException e){
 			log.error("Error deleting file from s3");
 		}
+	}
+
+	public void moveFile(String oldKey, String newKey) {
+		String bucketName = amazonConfig.getBucket();
+
+		amazonS3.copyObject(bucketName, oldKey, bucketName, newKey);
+		amazonS3.deleteObject(bucketName, oldKey);
+		log.debug("Moving file: oldKey={}, newKey={}", oldKey, newKey);
+	}
+
+	public String getFileUrl(String key) {
+		return amazonS3.getUrl(amazonConfig.getBucket(), key).toString();
+	}
+
+	public String extractFileKeyFromUrl(String url) {
+		String bucketName = amazonConfig.getBucket();
+		String splitStr = ".com/";
+		return url.substring(url.lastIndexOf(splitStr) + splitStr.length());
 	}
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #29 

## 🔑 Key Changes

1. 내용
    - 커뮤니티 게시글 생성 API 
    - 커뮤니티 게시글 수정 API
    - 커뮤니티 게시글 삭제 API
    - 커뮤니티 파일 임시 저장 API 구현
    
    - 커뮤니티 파일 임시 저장 API는 커뮤니티 게시글을 등록버튼을 누르기 전에(게시글을 쓰는 도중) 파일을 업로드하면 사진이 보여져야 됨. 그래서 s3에 temporary 폴더에 게시글 등록전에 파일을 저장함. 이후에 등록버튼을 누를 시에 temporary 폴더에서 community 폴더로 이동시켜 저장. temporary 폴더에 있는 파일들은 하루가 지나면 삭제하도록 설정

## 📸 Screenshot
![image](https://github.com/user-attachments/assets/b070968c-5467-4865-affa-06b492e41bce)

