### PR TITLE
Feature : 카테고리별 커뮤니티 게시물 조회 API

### DIFF
--- a/src/main/java/itstime/reflog/community/controller/CommunityController.java
+++ b/src/main/java/itstime/reflog/community/controller/CommunityController.java
@@ -133,5 +133,33 @@ public class CommunityController {
 		return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
 	}
 
+	//학습 유형 별 필터링 api
+	@Operation(
+			summary = "커뮤니티 게시글 카테고리별 조회 필터링 API",
+			description = "카테고리별 커뮤니티 게시글을 조회합니다. 카테고리를 파라미터에 입력하면 해당하는 게시글들 반환. 기타는 파라미터에 기타를 입력하면 됩니다. postTypes에는 글 유형, learningTypes에는 학습 유형을 각각 최대 두개까지 입력할 수 있습니다.",
+			responses = {
+					@ApiResponse(
+							responseCode = "200",
+							description = "카테고리별 커뮤니티 게시글 조회 성공"
+					),
+					@ApiResponse(
+							responseCode = "404",
+							description = "해당 카테고리를 찾을 수 없음"
+					),
+					@ApiResponse(
+							responseCode = "500",
+							description = "서버 에러"
+					)
+			}
+	)
+	@GetMapping("/filter")
+	public ResponseEntity<CommonApiResponse<List<CommunityDto.CommunityCategoryResponse>>> getFilteredCommunity(
+			@RequestParam(required = false) List<String> postTypes,
+			@RequestParam(required = false) List<String> learningTypes
+			){
+		List<CommunityDto.CommunityCategoryResponse> responses = .getRetrospect(categories, memberId);
+		return ResponseEntity.ok(CommonApiResponse.onSuccess(responses));
+	}
+
 
 }

--- a/src/main/java/itstime/reflog/community/controller/CommunityController.java
+++ b/src/main/java/itstime/reflog/community/controller/CommunityController.java
@@ -136,7 +136,8 @@ public class CommunityController {
 	//학습 유형 별 필터링 api
 	@Operation(
 			summary = "커뮤니티 게시글 카테고리별 조회 필터링 API",
-			description = "카테고리별 커뮤니티 게시글을 조회합니다. 카테고리를 파라미터에 입력하면 해당하는 게시글들 반환. 기타는 파라미터에 기타를 입력하면 됩니다. postTypes에는 글 유형, learningTypes에는 학습 유형을 각각 최대 두개까지 입력할 수 있습니다.",
+			description = "카테고리별 커뮤니티 게시글을 조회합니다. 카테고리를 파라미터에 입력하면 해당하는 게시글들 반환. 기타는 파라미터에 기타를 입력하면 됩니다. postTypes에는 글 유형, learningTypes에는 학습 유형을 각각 최대 두개까지 입력할 수 있습니다." +
+					"postTypes이 회고일지일 경우 회고일지를 반환합니다 understandinglevel,progresslevel도 반환 회고일지 아닌 경우 null",
 			responses = {
 					@ApiResponse(
 							responseCode = "200",

--- a/src/main/java/itstime/reflog/community/controller/CommunityController.java
+++ b/src/main/java/itstime/reflog/community/controller/CommunityController.java
@@ -153,11 +153,11 @@ public class CommunityController {
 			}
 	)
 	@GetMapping("/filter")
-	public ResponseEntity<CommonApiResponse<List<CommunityDto.CommunityCategoryResponse>>> getFilteredCommunity(
+	public ResponseEntity<CommonApiResponse<List<CommunityDto.CombinedCategoryResponse>>> getFilteredCommunity(
 			@RequestParam(required = false) List<String> postTypes,
 			@RequestParam(required = false) List<String> learningTypes
 			){
-		List<CommunityDto.CommunityCategoryResponse> responses = communityService.getFilteredCommunity(postTypes, learningTypes);
+		List<CommunityDto.CombinedCategoryResponse> responses = communityService.getFilteredCommunity(postTypes, learningTypes);
 		return ResponseEntity.ok(CommonApiResponse.onSuccess(responses));
 	}
 

--- a/src/main/java/itstime/reflog/community/controller/CommunityController.java
+++ b/src/main/java/itstime/reflog/community/controller/CommunityController.java
@@ -157,7 +157,7 @@ public class CommunityController {
 			@RequestParam(required = false) List<String> postTypes,
 			@RequestParam(required = false) List<String> learningTypes
 			){
-		List<CommunityDto.CommunityCategoryResponse> responses = .getRetrospect(categories, memberId);
+		List<CommunityDto.CommunityCategoryResponse> responses = communityService.getFilteredCommunity(postTypes, learningTypes);
 		return ResponseEntity.ok(CommonApiResponse.onSuccess(responses));
 	}
 

--- a/src/main/java/itstime/reflog/community/domain/Community.java
+++ b/src/main/java/itstime/reflog/community/domain/Community.java
@@ -37,12 +37,12 @@ public class Community {
 
 	private String content; // 게시글 내용
 
-	@ElementCollection
+	@ElementCollection(fetch = FetchType.EAGER)
 	@CollectionTable(name = "community_post_types", joinColumns = @JoinColumn(name = "community_id"))
 	@Column(name = "post_type")
 	private List<String> postTypes; // 글 유형 (최대 2개)
 
-	@ElementCollection
+	@ElementCollection(fetch = FetchType.EAGER)
 	@CollectionTable(name = "community_learning_types", joinColumns = @JoinColumn(name = "community_id"))
 	@Column(name = "learning_type")
 	private List<String> learningTypes; // 학습 유형 (최대 2개)

--- a/src/main/java/itstime/reflog/community/dto/CommunityDto.java
+++ b/src/main/java/itstime/reflog/community/dto/CommunityDto.java
@@ -31,6 +31,7 @@ public class CommunityDto {
 	public static class CombinedCategoryResponse {
 
 		private String title;
+		private String content;
 		private LocalDateTime createdDate; // Retrospect는 LocalDate로 변경 가능
 		private List<String> postTypes;
 		private List<String> learningTypes;
@@ -41,6 +42,7 @@ public class CommunityDto {
 		public static CombinedCategoryResponse fromCommunity(Community community, String writer) {
 			return CombinedCategoryResponse.builder()
 					.title(community.getTitle())
+					.content(community.getContent())
 					.createdDate(community.getCreatedAt())
 					.postTypes(community.getPostTypes())
 					.learningTypes(community.getLearningTypes())

--- a/src/main/java/itstime/reflog/community/dto/CommunityDto.java
+++ b/src/main/java/itstime/reflog/community/dto/CommunityDto.java
@@ -35,17 +35,14 @@ public class CommunityDto {
 		private List<String> learningTypes;
 		private String writer;
 
-		public static List<CommunityCategoryResponse> fromEntity(List<Community> communities, String writer) {
-			return communities.stream()
-					.map(community -> CommunityCategoryResponse.builder()
-							.title(community.getTitle())
-							.createdDate(community.getCreatedAt())
-							.postTypes(community.getPostTypes())
-							.learningTypes(community.getLearningTypes())
-							.writer(writer)
-							.build()
-					)
-					.collect(Collectors.toList());
+		public static CommunityCategoryResponse fromEntity(Community community, String writer) {
+			return CommunityCategoryResponse.builder()
+					.title(community.getTitle())
+					.createdDate(community.getCreatedAt())
+					.postTypes(community.getPostTypes())
+					.learningTypes(community.getLearningTypes())
+					.writer(writer)
+					.build();
 		}
 	}
 }

--- a/src/main/java/itstime/reflog/community/dto/CommunityDto.java
+++ b/src/main/java/itstime/reflog/community/dto/CommunityDto.java
@@ -1,10 +1,13 @@
 package itstime.reflog.community.dto;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import itstime.reflog.community.domain.Community;
+import itstime.reflog.member.domain.Member;
+import lombok.*;
 
 public class CommunityDto {
 
@@ -16,5 +19,33 @@ public class CommunityDto {
 		private List<String> postTypes;
 		private List<String> learningTypes;
 		private List<String> fileUrls;
+	}
+
+	//카테고리 별 필터링 api dto
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class CommunityCategoryResponse {
+
+		private String title;
+		private String content;
+		private LocalDateTime createdDate;
+		private List<String> postTypes;
+		private List<String> learningTypes;
+		private String writer;
+
+		public static List<CommunityCategoryResponse> fromEntity(List<Community> communities, String writer) {
+			return communities.stream()
+					.map(community -> CommunityCategoryResponse.builder()
+							.title(community.getTitle())
+							.createdDate(community.getCreatedAt())
+							.postTypes(community.getPostTypes())
+							.learningTypes(community.getLearningTypes())
+							.writer(writer)
+							.build()
+					)
+					.collect(Collectors.toList());
+		}
 	}
 }

--- a/src/main/java/itstime/reflog/community/dto/CommunityDto.java
+++ b/src/main/java/itstime/reflog/community/dto/CommunityDto.java
@@ -7,6 +7,8 @@ import java.util.stream.Collectors;
 
 import itstime.reflog.community.domain.Community;
 import itstime.reflog.member.domain.Member;
+import itstime.reflog.retrospect.domain.Retrospect;
+import itstime.reflog.retrospect.domain.StudyType;
 import lombok.*;
 
 public class CommunityDto {
@@ -26,21 +28,36 @@ public class CommunityDto {
 	@Builder
 	@AllArgsConstructor
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
-	public static class CommunityCategoryResponse {
+	public static class CombinedCategoryResponse {
 
 		private String title;
-		private String content;
-		private LocalDateTime createdDate;
+		private LocalDateTime createdDate; // Retrospect는 LocalDate로 변경 가능
 		private List<String> postTypes;
 		private List<String> learningTypes;
 		private String writer;
+		private Integer progressLevel;    // Retrospect 전용
+		private Integer understandingLevel; // Retrospect 전용
 
-		public static CommunityCategoryResponse fromEntity(Community community, String writer) {
-			return CommunityCategoryResponse.builder()
+		public static CombinedCategoryResponse fromCommunity(Community community, String writer) {
+			return CombinedCategoryResponse.builder()
 					.title(community.getTitle())
 					.createdDate(community.getCreatedAt())
 					.postTypes(community.getPostTypes())
 					.learningTypes(community.getLearningTypes())
+					.writer(writer)
+					.build();
+		}
+
+		public static CombinedCategoryResponse fromRetrospect(Retrospect retrospect, String writer) {
+			return CombinedCategoryResponse.builder()
+					.title(retrospect.getTitle())
+					.createdDate(retrospect.getCreatedDate().atStartOfDay())
+					.postTypes(List.of("회고일지")) // 단일 값을 리스트로 변환
+					.learningTypes(retrospect.getStudyTypes().stream()
+							.map(studyType -> studyType.getType()) // StudyType을 String으로 변환
+							.collect(Collectors.toList())) //String 리스트로 변환
+					.progressLevel(retrospect.getProgressLevel())
+					.understandingLevel(retrospect.getUnderstandingLevel())
 					.writer(writer)
 					.build();
 		}

--- a/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
+++ b/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
@@ -1,8 +1,17 @@
 package itstime.reflog.community.repository;
 
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import itstime.reflog.community.domain.Community;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface CommunityRepository extends JpaRepository<Community, Long> {
+
+    @Query("SELECT c FROM Community c WHERE (COALESCE(:learningTypes, NULL) IS NULL OR c.learningTypes IN :learningTypes) " +
+            "AND (COALESCE(:postTypes, NULL) IS NULL OR c.postTypes IN :postTypes)")
+    List<Community> findByLearningTypesAndPostTypes(
+            @Param("learningTypes") List<String> learningTypes, @Param("postTypes") List<String> postTypes);
 }

--- a/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
+++ b/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
@@ -1,6 +1,7 @@
 package itstime.reflog.community.repository;
 
 import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import itstime.reflog.community.domain.Community;

--- a/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
+++ b/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
@@ -10,8 +10,8 @@ import java.util.List;
 
 public interface CommunityRepository extends JpaRepository<Community, Long> {
 
-    @Query("SELECT c FROM Community c WHERE (COALESCE(:learningTypes, NULL) IS NULL OR c.learningTypes IN :learningTypes) " +
-            "AND (COALESCE(:postTypes, NULL) IS NULL OR c.postTypes IN :postTypes)")
+    @Query("SELECT DISTINCT c FROM Community c JOIN c.learningTypes lt JOIN c.postTypes pt " +
+            "WHERE (:learningTypes IS NULL OR lt IN :learningTypes) AND (:postTypes IS NULL OR pt IN :postTypes)")
     List<Community> findByLearningTypesAndPostTypes(
-            @Param("learningTypes") List<String> learningTypes, @Param("postTypes") List<String> postTypes);
+            @Param("postTypes") List<String> postTypes, @Param("learningTypes") List<String> learningTypes);
 }

--- a/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
+++ b/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
@@ -15,4 +15,10 @@ public interface CommunityRepository extends JpaRepository<Community, Long> {
             "WHERE (:learningTypes IS NULL OR lt IN :learningTypes) AND (:postTypes IS NULL OR pt IN :postTypes)")
     List<Community> findByLearningTypesAndPostTypes(
             @Param("postTypes") List<String> postTypes, @Param("learningTypes") List<String> learningTypes);
+
+    //기타는 기타:%s에 해당하는 모든 커뮤니티 반환
+    @Query("SELECT DISTINCT c FROM Community c JOIN c.learningTypes lt JOIN c.postTypes pt WHERE (:typePrefix IS NULL OR lt LIKE CONCAT(:typePrefix, '%')) " +
+            "AND (:postTypes IS NULL OR pt IN :postTypes) AND (:learningType IS NULL OR lt = :learningType)")
+    List<Community> findCommunitiesByLearningTypePrefix(@Param("postTypes") List<String> postTypes, @Param("typePrefix") String typePrefix, @Param("learningType") String learningType);
+
 }

--- a/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
+++ b/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
@@ -12,13 +12,14 @@ import java.util.List;
 public interface CommunityRepository extends JpaRepository<Community, Long> {
 
     @Query("SELECT DISTINCT c FROM Community c JOIN c.learningTypes lt JOIN c.postTypes pt " +
-            "WHERE (:learningTypes IS NULL OR lt IN :learningTypes) AND (:postTypes IS NULL OR pt IN :postTypes)")
+            "WHERE (:learningTypes IS NULL AND :postTypes IS NULL) OR (lt IN :learningTypes OR pt IN :postTypes)")
     List<Community> findByLearningTypesAndPostTypes(
             @Param("postTypes") List<String> postTypes, @Param("learningTypes") List<String> learningTypes);
 
     //기타는 기타:%s에 해당하는 모든 커뮤니티 반환
-    @Query("SELECT DISTINCT c FROM Community c JOIN c.learningTypes lt JOIN c.postTypes pt WHERE (:typePrefix IS NULL OR lt LIKE CONCAT(:typePrefix, '%')) " +
-            "AND (:postTypes IS NULL OR pt IN :postTypes) AND (:learningType IS NULL OR lt = :learningType)")
+    @Query("SELECT DISTINCT c FROM Community c JOIN c.learningTypes lt JOIN c.postTypes pt WHERE (:typePrefix IS NULL AND :postTypes IS NULL AND :learningType IS NULL) " +
+            "OR (lt LIKE CONCAT(:typePrefix, '%') OR pt IN :postTypes OR lt = :learningType)")
     List<Community> findCommunitiesByLearningTypePrefix(@Param("postTypes") List<String> postTypes, @Param("typePrefix") String typePrefix, @Param("learningType") String learningType);
+
 
 }

--- a/src/main/java/itstime/reflog/community/service/CommunityService.java
+++ b/src/main/java/itstime/reflog/community/service/CommunityService.java
@@ -136,7 +136,22 @@ public class CommunityService {
 	//커뮤니티 게시글 필터링
 	@Transactional
 	public List<CommunityDto.CommunityCategoryResponse> getFilteredCommunity(List<String> postTypes, List<String> learningTypes) {
-		List<Community> communities = communityRepository.findByLearningTypesAndPostTypes(postTypes, learningTypes);
+
+		List<Community> communities;
+
+		if (learningTypes != null && learningTypes.contains("기타")){ //학습유형에 기타가 포함된 경우
+			String typePrefix = "기타:%";
+
+			//기타가 아닌 나머지 학습 유형,, 만약 학습유형이 기타 하나라면 나머지는 null
+			String remainingLearningType = learningTypes.stream()
+					.filter(type -> !"기타".equals(type))
+					.findFirst()
+					.orElse(null); // 기타만 있을 경우 null
+
+			communities = communityRepository.findCommunitiesByLearningTypePrefix(postTypes, typePrefix,remainingLearningType);
+		}else {
+			communities = communityRepository.findByLearningTypesAndPostTypes(postTypes, learningTypes);
+		}
 
 
 		List<CommunityDto.CommunityCategoryResponse> filteredCommunities= communities.stream()

--- a/src/main/java/itstime/reflog/community/service/CommunityService.java
+++ b/src/main/java/itstime/reflog/community/service/CommunityService.java
@@ -129,4 +129,13 @@ public class CommunityService {
 		// 4. Community 삭제
 		communityRepository.delete(community);
 	}
+
+	//커뮤니티 게시글 필터링
+	@Transactional(readOnly = true)
+	public List<CommunityDto.CommunityCategoryResponse> getFilteredCommunity(List<String> learningTypes, List<String> postTypes) {
+		List<Community> communities = communityRepository.findByLearningTypesAndPostTypes(learningTypes, postTypes);
+
+		return CommunityDto.CommunityCategoryResponse.fromEntity(communities, );
+	}
+
 }

--- a/src/main/java/itstime/reflog/community/service/CommunityService.java
+++ b/src/main/java/itstime/reflog/community/service/CommunityService.java
@@ -32,7 +32,6 @@ public class CommunityService {
 	private final MemberRepository memberRepository;
 	private final MyPageRepository myPageRepository;
 
-
 	@Transactional
 	public void createCommunity(Long memberId, CommunityDto.CommunitySaveOrUpdateRequest dto) {
 		Member member = memberRepository.findById(memberId)
@@ -134,20 +133,25 @@ public class CommunityService {
 		// 4. Community 삭제
 		communityRepository.delete(community);
 	}
-
 	//커뮤니티 게시글 필터링
-	@Transactional(readOnly = true)
-	public List<CommunityDto.CommunityCategoryResponse> getFilteredCommunity(List<String> postTypes,List<String> learningTypes) {
+	@Transactional
+	public List<CommunityDto.CommunityCategoryResponse> getFilteredCommunity(List<String> postTypes, List<String> learningTypes) {
 		List<Community> communities = communityRepository.findByLearningTypesAndPostTypes(postTypes, learningTypes);
 
-		return communities.stream()
+
+		List<CommunityDto.CommunityCategoryResponse> filteredCommunities= communities.stream()
 				.map(community -> {
+
 					String nickname = myPageRepository.findByMember(community.getMember())
 							.map(MyPage::getNickname)
-							.orElse("닉네임 없음"); // 닉네임이 없을 경우
+							.orElse("닉네임 없음");
+
 					return CommunityDto.CommunityCategoryResponse.fromEntity(community, nickname);
 				})
 				.collect(Collectors.toList());
+
+		return filteredCommunities;
 	}
+
 
 }

--- a/src/main/java/itstime/reflog/config/SecurityConfig.java
+++ b/src/main/java/itstime/reflog/config/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(requests -> requests
-                        .requestMatchers("/test", "/swagger-ui/index.html", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/v3/api-docs", "/api/v1/todo/**", "/api/v1/learn/**", "/api/v1/plan/**", "/api/v1/weekly-analysis/**","/api/v1/monthly-analysis/**","/api/v1/retrospect/**","/api/v1/mypage/**","/api/v1/notifications/**").permitAll()
+                        .requestMatchers("/test", "/swagger-ui/index.html", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/v3/api-docs", "/api/v1/todo/**", "/api/v1/learn/**", "/api/v1/plan/**", "/api/v1/weekly-analysis/**","/api/v1/monthly-analysis/**","/api/v1/retrospect/**","/api/v1/mypage/**","/api/v1/notifications/**","/api/v1/communities/**").permitAll()
                         .anyRequest().authenticated()           // 나머지 URL은 인증 필요
                 )
                 // .addFilterBefore(new TokenAuthenticationFilter(jwtTokenProvider()), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/itstime/reflog/mypage/repository/MyPageRepository.java
+++ b/src/main/java/itstime/reflog/mypage/repository/MyPageRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 @Repository
 public interface MyPageRepository extends JpaRepository<MyPage, Long> {
     Optional<MyPage> findByMember(Member member);
+
 }

--- a/src/main/java/itstime/reflog/retrospect/repository/RetrospectRepository.java
+++ b/src/main/java/itstime/reflog/retrospect/repository/RetrospectRepository.java
@@ -19,4 +19,6 @@ public interface RetrospectRepository extends JpaRepository<Retrospect, Long> {
 
     List<Retrospect> findByMember(Member member);
 
+	List<Retrospect> findByVisibilityIsTrue();
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,7 @@
 spring:
   profiles:
     active: aws
+logging:
+  level:
+    org:
+      springframework: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,3 @@
 spring:
   profiles:
     active: aws
-logging:
-  level:
-    org:
-      springframework: DEBUG


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #36 

## 🔑 Key Changes

1. 내용
    - 학습유형, 글 유형 별로 커뮤니티 게시물 조회하도록 함
    - 학습유형, 글 유형은 스트링 형태의 리스트로 파라미터 받음
    - 레포지토리에서 기타가 있는 경우, 없는 경우 두개의 메서드 만들어서 서비스 코드에서 케이스 분류해 다른 메서드 쓰도록함
    - 처음에는 회고일지가 있는걸 잊고 커뮤니티 게시물만 생각해 dto를 만들었는데 이후 회고일지도 생각해 understanding, progresslevel도 추가 -> 이것도 글 유형에 회고일지 있는 경우 회고일지 레포지토리에 visibility true인 회고일지 가져올수있도록 메서드 추가
    - 아직 학습유형, 글 유형 각각 최대 두개씩 올수있도록 예외 처리는 못함,, 리팩토링때 할 예정
    

> 아 그리고 지연 로딩때문에 계속 Community 엔티티가 초기화가 되기 전에 postTypes, learningTypes을 불러와 LazyInitializationException 에러가 발생해서 Community 도메인에서 postTypes, learningTypes에 FetchType.EAGER을 추가했..어욤.. 다른 더 좋은 방법이 있다면 바꿔두겠습니다요..!

## 📸 Screenshot
<img width="1376" alt="스크린샷 2025-01-04 오전 1 11 55" src="https://github.com/user-attachments/assets/9c665ce2-35b8-48ed-93d8-e641d781b642" />
<img width="1253" alt="스크린샷 2025-01-04 오전 1 05 04" src="https://github.com/user-attachments/assets/52c9290d-dd6e-4460-be12-a7cb89efac63" />
<img width="1245" alt="스크린샷 2025-01-04 오전 1 05 25" src="https://github.com/user-attachments/assets/69547a52-a907-4600-ba07-933d0f2ee283" />
