### PR TITLE
Feature : 커뮤니티 검색 API 구현

### DIFF
--- a/src/main/java/itstime/reflog/community/controller/CommunityController.java
+++ b/src/main/java/itstime/reflog/community/controller/CommunityController.java
@@ -162,5 +162,31 @@ public class CommunityController {
 		return ResponseEntity.ok(CommonApiResponse.onSuccess(responses));
 	}
 
+	@Operation(
+			summary = "커뮤니티 게시글 검색 API",
+			description = "카테고리별 커뮤니티 게시글을 검색합니다. 파라미터에 검색하고자 하는 string을 입력하면 일치하는 게시물을 반환합니다",
+			responses = {
+					@ApiResponse(
+							responseCode = "200",
+							description = "커뮤니티 게시글 검색 성공"
+					),
+					@ApiResponse(
+							responseCode = "404",
+							description = "입력하신 제목과 일치하는 게시물을 찾을 수 없음"
+					),
+					@ApiResponse(
+							responseCode = "500",
+							description = "서버 에러"
+					)
+			}
+	)
+	@GetMapping("/search")
+	public ResponseEntity<CommonApiResponse<List<CommunityDto.CombinedCategoryResponse>>> getSearchedCommunity(
+			@RequestParam(required = false) String title
+	){
+		List<CommunityDto.CombinedCategoryResponse> responses = communityService.getSearchedCommunity(title);
+		return ResponseEntity.ok(CommonApiResponse.onSuccess(responses));
+	}
+
 
 }

--- a/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
+++ b/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
@@ -21,5 +21,6 @@ public interface CommunityRepository extends JpaRepository<Community, Long> {
             "OR (lt LIKE CONCAT(:typePrefix, '%') OR pt IN :postTypes OR lt = :learningType)")
     List<Community> findCommunitiesByLearningTypePrefix(@Param("postTypes") List<String> postTypes, @Param("typePrefix") String typePrefix, @Param("learningType") String learningType);
 
-
+    @Query("SELECT c FROM Community c WHERE c.title LIKE %:title%")
+    List<Community> searchCommunitiesByTitleContaining(@Param("title") String title);
 }

--- a/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
+++ b/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
@@ -21,6 +21,7 @@ public interface CommunityRepository extends JpaRepository<Community, Long> {
             "OR (lt LIKE CONCAT(:typePrefix, '%') OR pt IN :postTypes OR lt = :learningType)")
     List<Community> findCommunitiesByLearningTypePrefix(@Param("postTypes") List<String> postTypes, @Param("typePrefix") String typePrefix, @Param("learningType") String learningType);
 
+    //제목에 키워드를 포함하고 있는 게시물 찾기
     @Query("SELECT c FROM Community c WHERE c.title LIKE %:title%")
     List<Community> searchCommunitiesByTitleContaining(@Param("title") String title);
 }

--- a/src/main/java/itstime/reflog/community/service/CommunityService.java
+++ b/src/main/java/itstime/reflog/community/service/CommunityService.java
@@ -182,5 +182,37 @@ public class CommunityService {
 		return responses;
 	}
 
+	//커뮤니티 게시물 검색
+	@Transactional
+	public List<CommunityDto.CombinedCategoryResponse> getSearchedCommunity(String title){
+
+		//커뮤니티 게시물 중 키워드가 일치하는 게시물 찾기
+		List<Community> communities= communityRepository.searchCommunitiesByTitleContaining(title);
+
+		List<CommunityDto.CombinedCategoryResponse> responses = communities.stream()
+				.map(community -> {
+					String nickname = myPageRepository.findByMember(community.getMember())
+							.map(MyPage::getNickname)
+							.orElse("닉네임 없음");
+					return CommunityDto.CombinedCategoryResponse.fromCommunity(community, nickname);
+				})
+				.collect(Collectors.toList());
+
+		//회고일지 게시물 중 키워드가 일치하는 게시물 찾기
+		List<Retrospect> retrospects = retrospectRepository.findByTitleContainingAndVisibilityIsTrue(title);
+
+		List<CommunityDto.CombinedCategoryResponse> retrospectResponses = retrospects.stream()
+				.map(retrospect -> {
+					String nickname = myPageRepository.findByMember(retrospect.getMember())
+							.map(MyPage::getNickname)
+							.orElse("닉네임 없음");
+					return CommunityDto.CombinedCategoryResponse.fromRetrospect(retrospect, nickname);
+				})
+				.collect(Collectors.toList());
+		responses.addAll(retrospectResponses); // 두 리스트 합치기(회고일지, 커뮤니티)
+
+		return responses;
+	}
+
 
 }

--- a/src/main/java/itstime/reflog/retrospect/repository/RetrospectRepository.java
+++ b/src/main/java/itstime/reflog/retrospect/repository/RetrospectRepository.java
@@ -2,6 +2,8 @@ package itstime.reflog.retrospect.repository;
 
 import java.time.LocalDate;
 import java.util.Optional;
+
+import itstime.reflog.community.domain.Community;
 import itstime.reflog.member.domain.Member;
 import itstime.reflog.retrospect.domain.StudyType;
 import itstime.reflog.todolist.domain.Todolist;
@@ -29,4 +31,8 @@ public interface RetrospectRepository extends JpaRepository<Retrospect, Long> {
 	//기타는 기타:%s에 해당하는 모든 회고일지 반환
 	@Query("SELECT r FROM Retrospect r JOIN r.studyTypes st WHERE st.type LIKE :typePrefix AND r.member = :member")
 	List<Retrospect> findRetrospectsByTypePrefixAndMember(@Param("typePrefix") String typePrefix, @Param("member") Member member);
+
+	//검색 API
+	@Query("SELECT r FROM Retrospect r WHERE r.visibility = true AND r.title LIKE %:title%")
+	List<Retrospect> findByTitleContainingAndVisibilityIsTrue(@Param("title") String title);
 }

--- a/src/main/java/itstime/reflog/retrospect/repository/RetrospectRepository.java
+++ b/src/main/java/itstime/reflog/retrospect/repository/RetrospectRepository.java
@@ -32,7 +32,7 @@ public interface RetrospectRepository extends JpaRepository<Retrospect, Long> {
 	@Query("SELECT r FROM Retrospect r JOIN r.studyTypes st WHERE st.type LIKE :typePrefix AND r.member = :member")
 	List<Retrospect> findRetrospectsByTypePrefixAndMember(@Param("typePrefix") String typePrefix, @Param("member") Member member);
 
-	//검색 API
+	//제목에 키워드를 포함하고 공개로 설정된 회고일지 찾기
 	@Query("SELECT r FROM Retrospect r WHERE r.visibility = true AND r.title LIKE %:title%")
 	List<Retrospect> findByTitleContainingAndVisibilityIsTrue(@Param("title") String title);
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #43

## 🔑 Key Changes

1. 내용
    - 키워드로 검색을 하면 해당 키워드를 포함하는 제목을 가진 커뮤니티 게시물들 반환하도록 햇습니당
    - 커뮤니티 엔티티에서 찾는 메서드와 회고일지 엔티티 중에서 공개로 설정된 회고일지 중 키워드와 일치하는 게시물들 반환하는 메서드 레포지토리에 각각 작성

## 📸 Screenshot
<img width="1228" alt="스크린샷 2025-01-05 오후 4 27 54" src="https://github.com/user-attachments/assets/3e1280c1-371c-484e-a51b-9a43d34ba5a1" />
<img width="998" alt="스크린샷 2025-01-05 오후 4 27 37" src="https://github.com/user-attachments/assets/0081cbae-9d17-41e0-bf01-fccd75813827" />
