### PR TITLE
Feature : 커뮤니티 게시물 전체 조회 API 구현

### DIFF
--- a/src/main/java/itstime/reflog/community/controller/CommunityController.java
+++ b/src/main/java/itstime/reflog/community/controller/CommunityController.java
@@ -186,7 +186,7 @@ public class CommunityController {
 
 	@Operation(
 		summary = "커뮤니티 게시글 검색 API",
-		description = "카테고리별 커뮤니티 게시글을 검색합니다. 파라미터에 검색하고자 하는 string을 입력하면 일치하는 게시물을 반환합니다",
+		description = "커뮤니티 게시글을 검색합니다. 파라미터에 검색하고자 하는 string을 입력하면 일치하는 게시물을 반환합니다",
 		responses = {
 			@ApiResponse(
 				responseCode = "200",
@@ -239,5 +239,30 @@ public class CommunityController {
 		return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
 	}
 
+	@Operation(
+			summary = "커뮤니티 게시물 전체 조회 API",
+			description = "커뮤니티 게시물들을 조회합니다. 최신순으로 정렬되어있습니다.",
+			responses = {
+					@ApiResponse(
+							responseCode = "200",
+							description = "커뮤니티 게시글 조회 성공"
+					),
+					@ApiResponse(
+							responseCode = "404",
+							description = "해당 회원을 찾을 수 없음"
+					),
+					@ApiResponse(
+							responseCode = "500",
+							description = "서버 에러"
+					)
+			}
+	)
+	@GetMapping
+	public ResponseEntity<CommonApiResponse<List<CommunityDto.CombinedCategoryResponse>>> getAllCommunity(
+			@RequestParam Long memberId
+	){
+		List<CommunityDto.CombinedCategoryResponse> responses = communityService.getAllCommunity(memberId);
+		return ResponseEntity.ok(CommonApiResponse.onSuccess(responses));
+	}
 
 }

--- a/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
+++ b/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
@@ -25,8 +25,6 @@ public interface CommunityRepository extends JpaRepository<Community, Long> {
     @Query("SELECT c FROM Community c WHERE c.title LIKE %:title%")
     List<Community> searchCommunitiesByTitleContaining(@Param("title") String title);
 
-    //만약 업데이트 필드가 널이 아니라면 업데이트 필드 기준 정렬 사용,, 업데이트 필드가 널이라면 생성 날짜 기준 정렬
-    @Query("SELECT c FROM Community c ORDER BY CASE WHEN c.updatedAt IS NOT NULL THEN c.updatedAt ELSE " +
-            "c.createdAt END DESC")
-    List<Community> getCommunitiesInorder();
+    //최신 순 정렬
+    List<Community> findAllByOrderByCreatedAtDesc();
 }

--- a/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
+++ b/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
@@ -24,4 +24,9 @@ public interface CommunityRepository extends JpaRepository<Community, Long> {
     //제목에 키워드를 포함하고 있는 게시물 찾기
     @Query("SELECT c FROM Community c WHERE c.title LIKE %:title%")
     List<Community> searchCommunitiesByTitleContaining(@Param("title") String title);
+
+    //만약 업데이트 필드가 널이 아니라면 업데이트 필드 기준 정렬 사용,, 업데이트 필드가 널이라면 생성 날짜 기준 정렬
+    @Query("SELECT c FROM Community c ORDER BY CASE WHEN c.updatedAt IS NOT NULL THEN c.updatedAt ELSE " +
+            "c.createdAt END DESC")
+    List<Community> getCommunitiesInorder();
 }

--- a/src/main/java/itstime/reflog/community/service/CommunityService.java
+++ b/src/main/java/itstime/reflog/community/service/CommunityService.java
@@ -284,5 +284,15 @@ public class CommunityService {
 		return responses;
 	}
 
+    @Transactional
+    public List<CommunityDto.CombinedCategoryResponse> getAllCommunity(Long memberId){
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
+
+        List<Community> communities = communityRepository.getCommunitiesInorder();
+        List<Retrospect> retrospects = retrospectRepository.getRetrospectInorder();
+
+
+    }
 
 }

--- a/src/main/java/itstime/reflog/community/service/CommunityService.java
+++ b/src/main/java/itstime/reflog/community/service/CommunityService.java
@@ -291,7 +291,7 @@ public class CommunityService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
 
         List<Community> communities = communityRepository.findAllByOrderByCreatedAtDesc();
-        List<Retrospect> retrospects = retrospectRepository.findAllByOrderByCreatedDateDesc();
+        List<Retrospect> retrospects = retrospectRepository.findAllByVisibilityTrueOrderByCreatedDateDesc();
 
         //회고일지, 커뮤니티 리스트를 합쳐 하나의 리스트로
         List<CommunityDto.CombinedCategoryResponse> responses = retrospects.stream().map(
@@ -327,7 +327,7 @@ public class CommunityService {
 
         responses.addAll(communityResponses);
 
-        //최신 순으로 정렬해주기
+        //최신 순으로 정렬해주기 : reversed() !
         responses.sort(Comparator.comparing(CommunityDto.CombinedCategoryResponse::getCreatedDate).reversed());
 
         return responses;

--- a/src/main/java/itstime/reflog/retrospect/repository/RetrospectRepository.java
+++ b/src/main/java/itstime/reflog/retrospect/repository/RetrospectRepository.java
@@ -37,6 +37,5 @@ public interface RetrospectRepository extends JpaRepository<Retrospect, Long> {
 	List<Retrospect> findByTitleContainingAndVisibilityIsTrue(@Param("title") String title);
 
 	//생성날짜 기준 정렬
-	@Query("SELECT r FROM Retrospect r ORDER BY r.createdDate DESC")
-	List<Retrospect> getRetrospectInorder();
+	List<Retrospect> findAllByOrderByCreatedDateDesc();
 }

--- a/src/main/java/itstime/reflog/retrospect/repository/RetrospectRepository.java
+++ b/src/main/java/itstime/reflog/retrospect/repository/RetrospectRepository.java
@@ -36,6 +36,6 @@ public interface RetrospectRepository extends JpaRepository<Retrospect, Long> {
 	@Query("SELECT r FROM Retrospect r WHERE r.visibility = true AND r.title LIKE %:title%")
 	List<Retrospect> findByTitleContainingAndVisibilityIsTrue(@Param("title") String title);
 
-	//생성날짜 기준 정렬
-	List<Retrospect> findAllByOrderByCreatedDateDesc();
+	//공개로 설정한 모든 회고일지 생성날짜 기준 정렬
+	List<Retrospect> findAllByVisibilityTrueOrderByCreatedDateDesc();
 }

--- a/src/main/java/itstime/reflog/retrospect/repository/RetrospectRepository.java
+++ b/src/main/java/itstime/reflog/retrospect/repository/RetrospectRepository.java
@@ -35,4 +35,8 @@ public interface RetrospectRepository extends JpaRepository<Retrospect, Long> {
 	//제목에 키워드를 포함하고 공개로 설정된 회고일지 찾기
 	@Query("SELECT r FROM Retrospect r WHERE r.visibility = true AND r.title LIKE %:title%")
 	List<Retrospect> findByTitleContainingAndVisibilityIsTrue(@Param("title") String title);
+
+	//생성날짜 기준 정렬
+	@Query("SELECT r FROM Retrospect r ORDER BY r.createdDate DESC")
+	List<Retrospect> getRetrospectInorder();
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #50 

## 🔑 Key Changes

1. 내용
    - 회고일지와 커뮤니티 게시물을 각각 최신순으로 가져오는 메서드 작성
    - 이후 각각의 fromEntity 함수를 이용해 응답 형태로 변경 후 리스트 합쳐서 생성일 역순으로 정렬

## 📸 Screenshot
<img width="938" alt="스크린샷 2025-01-07 오후 2 45 11" src="https://github.com/user-attachments/assets/a1601860-7fef-4a5c-ac2d-bca6a33f09cf" />
<img width="847" alt="스크린샷 2025-01-07 오후 2 45 28" src="https://github.com/user-attachments/assets/736aa7dc-7e39-4513-b87c-5e7c870348fa" />
