### PR TITLE
Feat : 로그아웃, 회원탈퇴 구현

### DIFF
--- a/src/main/java/itstime/reflog/member/controller/MemberController.java
+++ b/src/main/java/itstime/reflog/member/controller/MemberController.java
@@ -41,9 +41,8 @@ public class MemberController {
 	}
 
 	@DeleteMapping("/delete")
-	public ResponseEntity<CommonApiResponse<Void>> delete(@RequestHeader("Authorization") String accessToken) {
+	public ResponseEntity<CommonApiResponse<Void>> delete(@RequestParam("token") String token) {
 		// 1. Access Token에서 사용자 UUID 추출
-		String token = jwtUtil.getTokenFromHeader(accessToken);
 		UUID userId = jwtUtil.getUuidFromToken(token);
 
 		// 2. 사용자 데이터 삭제

--- a/src/main/java/itstime/reflog/member/controller/MemberController.java
+++ b/src/main/java/itstime/reflog/member/controller/MemberController.java
@@ -12,11 +12,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import itstime.reflog.common.CommonApiResponse;
 import itstime.reflog.member.service.MemberService;
 import itstime.reflog.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "MEMBER API", description = "멤버에 대한 API입니다.")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/")
@@ -26,6 +30,20 @@ public class MemberController {
 	private final RedisTemplate<String, String> redisTemplate;
 	private final MemberService memberService;
 
+	@Operation(
+		summary = "로그아웃 API",
+		description = "로그아웃 API입니다. request param으로 accesstoken 한번 더 보내주시면 됩니다. 로그아웃 API 호출하시고 스토리지에서 토큰 삭제해주세요. AccessToken 필요.",
+		responses = {
+			@ApiResponse(
+				responseCode = "200",
+				description = "로그아웃 성공"
+			),
+			@ApiResponse(
+				responseCode = "500",
+				description = "서버 에러"
+			)
+		}
+	)
 	@GetMapping("/logout")
 	public ResponseEntity<CommonApiResponse<Void>> logout(@RequestParam("token") String token) {
 		// 1. 사용자 ID 추출
@@ -40,6 +58,20 @@ public class MemberController {
 		return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
 	}
 
+	@Operation(
+		summary = "회원탈퇴 API",
+		description = "회원탈퇴 API입니다. request param으로 accesstoken 한번 더 보내주시면 됩니다. 회원탈퇴 API 호출하시고 스토리지에서 토큰 삭제해주세요. AccessToken 필요.",
+		responses = {
+			@ApiResponse(
+				responseCode = "200",
+				description = "회원탈퇴 성공"
+			),
+			@ApiResponse(
+				responseCode = "500",
+				description = "서버 에러"
+			)
+		}
+	)
 	@DeleteMapping("/delete")
 	public ResponseEntity<CommonApiResponse<Void>> delete(@RequestParam("token") String token) {
 		// 1. Access Token에서 사용자 UUID 추출

--- a/src/main/java/itstime/reflog/member/controller/MemberController.java
+++ b/src/main/java/itstime/reflog/member/controller/MemberController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import itstime.reflog.common.CommonApiResponse;
@@ -26,20 +27,16 @@ public class MemberController {
 	private final MemberService memberService;
 
 	@GetMapping("/logout")
-	public ResponseEntity<CommonApiResponse<Void>> logout(@RequestHeader("Authorization") String accessToken) {
-		// 1. Access Token에서 UUID 추출
-		String token = jwtUtil.getTokenFromHeader(accessToken);
+	public ResponseEntity<CommonApiResponse<Void>> logout(@RequestParam("token") String token) {
+		// 1. 사용자 ID 추출
 		UUID userId = jwtUtil.getUuidFromToken(token);
 
-		// 2. Access Token을 Redis 블랙리스트에 등록
+		// 2. Redis 블랙리스트 및 Refresh Token 삭제
 		long remainingTime = jwtUtil.getRemainingTime(token); // 토큰 만료 시간 계산
 		redisTemplate.opsForValue().set("blacklist:" + token, "true", remainingTime, TimeUnit.MILLISECONDS);
+		redisTemplate.delete("refresh:" + userId);
 
-		// 3. Refresh Token 삭제
-		String refreshTokenKey = "refresh:" + userId;
-		redisTemplate.delete(refreshTokenKey);
-
-		// 로그아웃 완료 응답
+		// 3. 로그아웃 완료 응답
 		return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
 	}
 

--- a/src/main/java/itstime/reflog/member/controller/MemberController.java
+++ b/src/main/java/itstime/reflog/member/controller/MemberController.java
@@ -1,0 +1,42 @@
+package itstime.reflog.member.controller;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import itstime.reflog.common.CommonApiResponse;
+import itstime.reflog.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/")
+public class MemberController {
+
+	private final JwtUtil jwtUtil;
+	private final RedisTemplate<String, String> redisTemplate;
+
+	@GetMapping("/logout")
+	public ResponseEntity<CommonApiResponse<Void>> logout(@RequestHeader("Authorization") String accessToken) {
+		// 1. Access Token에서 UUID 추출
+		String token = jwtUtil.getTokenFromHeader(accessToken);
+		UUID userId = jwtUtil.getUuidFromToken(token);
+
+		// 2. Access Token을 Redis 블랙리스트에 등록
+		long remainingTime = jwtUtil.getRemainingTime(token); // 토큰 만료 시간 계산
+		redisTemplate.opsForValue().set("blacklist:" + token, "true", remainingTime, TimeUnit.MILLISECONDS);
+
+		// 3. Refresh Token 삭제
+		String refreshTokenKey = "refresh:" + userId;
+		redisTemplate.delete(refreshTokenKey);
+
+		// 로그아웃 완료 응답
+		return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
+	}
+}

--- a/src/main/java/itstime/reflog/member/service/MemberService.java
+++ b/src/main/java/itstime/reflog/member/service/MemberService.java
@@ -1,0 +1,25 @@
+package itstime.reflog.member.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import itstime.reflog.common.code.status.ErrorStatus;
+import itstime.reflog.common.exception.GeneralException;
+import itstime.reflog.member.domain.Member;
+import itstime.reflog.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+	private final MemberRepository memberRepository;
+
+	public void deleteMember(UUID userId) {
+		// 1. 데이터베이스에서 회원 정보 삭제
+		Member member = memberRepository.findByUuid(userId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
+		memberRepository.delete(member);
+	}
+
+}

--- a/src/main/java/itstime/reflog/util/JwtUtil.java
+++ b/src/main/java/itstime/reflog/util/JwtUtil.java
@@ -60,6 +60,7 @@ public class JwtUtil {
 
     // 응답 헤더에서 액세스 토큰을 반환하는 메서드
     public String getTokenFromHeader(String authorizationHeader) {
+        System.out.println("Authorization Header: " + authorizationHeader);
         return authorizationHeader.substring(7);
     }
 

--- a/src/main/java/itstime/reflog/util/JwtUtil.java
+++ b/src/main/java/itstime/reflog/util/JwtUtil.java
@@ -98,4 +98,39 @@ public class JwtUtil {
             throw new TokenException(TokenErrorResult.INVALID_TOKEN);
         }
     }
+
+    public UUID getUuidFromToken(String token) {
+        try {
+            String userId = Jwts.parserBuilder()
+                .setSigningKey(this.getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("userId", String.class);
+
+            log.info("토큰에서 추출된 UUID: {}", userId);
+            return UUID.fromString(userId);
+        } catch (JwtException | IllegalArgumentException e) {
+            log.error("유효하지 않은 토큰입니다. 에러 메시지: {}", e.getMessage());
+            throw new TokenException(TokenErrorResult.INVALID_TOKEN);
+        }
+    }
+
+    public long getRemainingTime(String token) {
+        try {
+            Date expirationDate = Jwts.parserBuilder()
+                .setSigningKey(this.getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration();
+
+            long remainingTime = expirationDate.getTime() - System.currentTimeMillis();
+            log.info("토큰의 남은 유효 시간(ms): {}", remainingTime);
+            return remainingTime > 0 ? remainingTime : 0;
+        } catch (JwtException e) {
+            log.error("토큰 만료 시간 확인 중 에러 발생: {}", e.getMessage());
+            throw new TokenException(TokenErrorResult.INVALID_TOKEN);
+        }
+    }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #47

## 🔑 Key Changes

1. 내용
    - 로그아웃
    - 회원탈퇴
    - 로그아웃 시 토큰을 블랙리스트에 추가 -> api 호출 전 블랙리스트 검토하는 코드 필요한데 jwtfilter 코드 부분이 없어서 추가를 못함. 프론트측에서 로그아웃 시에 스토리지에서 토큰을 삭제할거라 급한 문제는 아닌것 같아 일단 pr 날림
    - 회원탈퇴 시 토큰 삭제, 멤버 삭제 

## 📸 Screenshot

