### PR TITLE
Feat: 인기글 조회 API 구현

### DIFF
--- a/src/main/java/itstime/reflog/common/code/status/ErrorStatus.java
+++ b/src/main/java/itstime/reflog/common/code/status/ErrorStatus.java
@@ -61,6 +61,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
 	//PostLike 관련 에러
 	_POSTLIKE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "POSTLIKE400", "올바른 PostType을 입력해주세요."),
+	_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POSTLIKE404", "해당 게시물이 존재하지 않습니다"),
 	// comment 관련 에러
 	_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT404", "해당 댓글을 찾을 수 없습니다."),
 	_PARENT_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT404", "해당 부모 댓글을 찾을 수 없습니다.");

--- a/src/main/java/itstime/reflog/community/controller/CommunityController.java
+++ b/src/main/java/itstime/reflog/community/controller/CommunityController.java
@@ -265,4 +265,31 @@ public class CommunityController {
 		return ResponseEntity.ok(CommonApiResponse.onSuccess(responses));
 	}
 
+	@Operation(
+			summary = "커뮤니티 인기글 조회 API",
+			description = "좋아요를 많이 받은 게시물 세개를 조회합니다. 매일 갱신됨",
+			responses = {
+					@ApiResponse(
+							responseCode = "200",
+							description = "커뮤니티 인기글 조회 성공"
+					),
+					@ApiResponse(
+							responseCode = "404",
+							description = "인기글을 찾을 수 없음"
+					),
+					@ApiResponse(
+							responseCode = "500",
+							description = "서버 에러"
+					)
+			}
+	)
+	@GetMapping("/popular")
+	public ResponseEntity<CommonApiResponse<List<CommunityDto.CombinedCategoryResponse>>> getTopLikeCommunityPosts(
+			@RequestParam Long memberId
+	)
+	{
+		List<CommunityDto.CombinedCategoryResponse> responses = postLikeService.getTopLikeCommunityPosts(memberId);
+		return ResponseEntity.ok(CommonApiResponse.onSuccess(responses));
+	}
+
 }

--- a/src/main/java/itstime/reflog/config/RedisConfig.java
+++ b/src/main/java/itstime/reflog/config/RedisConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -39,4 +40,5 @@ public class RedisConfig {
         redisTemplate.afterPropertiesSet();
         return redisTemplate;
     }
+
 }

--- a/src/main/java/itstime/reflog/postlike/domain/PopularPost.java
+++ b/src/main/java/itstime/reflog/postlike/domain/PopularPost.java
@@ -1,0 +1,24 @@
+package itstime.reflog.postlike.domain;
+
+import itstime.reflog.postlike.domain.enums.PostType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PopularPost {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long postId;
+
+    @Enumerated(EnumType.STRING)
+    private PostType postType;
+}

--- a/src/main/java/itstime/reflog/postlike/repository/PopularPostRepository.java
+++ b/src/main/java/itstime/reflog/postlike/repository/PopularPostRepository.java
@@ -1,0 +1,7 @@
+package itstime.reflog.postlike.repository;
+
+import itstime.reflog.postlike.domain.PopularPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PopularPostRepository extends JpaRepository<PopularPost, Long> {
+}

--- a/src/main/java/itstime/reflog/postlike/repository/PostLikeRepository.java
+++ b/src/main/java/itstime/reflog/postlike/repository/PostLikeRepository.java
@@ -31,12 +31,12 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
     //community 게시물 좋아요 많은 순으로 정렬하고 id, 좋아요 수 반환 : Object[0] = id, Object[1] = 좋아요 수
     //타입을 구분하기 위해 앞에 타입도 반환
-    @Query("SELECT 'COMMUNITY', pl.community.id, COUNT(pl) as likeCount FROM PostLike pl GROUP BY pl.community.id " +
+    @Query("SELECT 'COMMUNITY', pl.community.id, COUNT(pl) as likeCount FROM PostLike pl WHERE pl.postType = 'COMMUNITY' GROUP BY pl.community.id " +
             "ORDER BY likeCount DESC")
-    List<Object[]> findAllCommunityPostLikesTop();
+    List<Object[]> findCommunityByPostLikeTop();
 
     //retrospect 게시물 좋아요 많은 순으로 정렬
-    @Query("SELECT 'RETROSPECT', pl.retrospect.id, COUNT(pl) as likeCount FROM PostLike pl GROUP BY pl.retrospect.id " +
+    @Query("SELECT 'RETROSPECT', pl.retrospect.id, COUNT(pl) as likeCount FROM PostLike pl WHERE pl.postType = 'RETROSPECT' GROUP BY pl.retrospect.id " +
             "ORDER BY likeCount DESC")
-    List<Object[]> findAllRetrospectPostLikesTop();
+    List<Object[]> findARetrospectPostLikesTop();
 }

--- a/src/main/java/itstime/reflog/postlike/repository/PostLikeRepository.java
+++ b/src/main/java/itstime/reflog/postlike/repository/PostLikeRepository.java
@@ -28,4 +28,15 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
     // 내가 좋아요를 누른 모든 커뮤니티 or 회고일지 글
     List<PostLike> findAllByMemberAndPostType(Member member, PostType postType);
+
+    //community 게시물 좋아요 많은 순으로 정렬하고 id, 좋아요 수 반환 : Object[0] = id, Object[1] = 좋아요 수
+    //타입을 구분하기 위해 앞에 타입도 반환
+    @Query("SELECT 'community', pl.community.id, COUNT(pl) as likeCount FROM PostLike pl GROUP BY pl.community.id " +
+            "ORDER BY likeCount DESC")
+    List<Object[]> findAllCommunityPostLikesTop();
+
+    //retrospect 게시물 좋아요 많은 순으로 정렬
+    @Query("SELECT 'retrospect', pl.retrospect.id, COUNT(pl) as likeCount FROM PostLike pl GROUP BY pl.retrospect.id " +
+            "ORDER BY likeCount DESC")
+    List<Object[]> findAllRetrospectPostLikesTop();
 }

--- a/src/main/java/itstime/reflog/postlike/repository/PostLikeRepository.java
+++ b/src/main/java/itstime/reflog/postlike/repository/PostLikeRepository.java
@@ -31,12 +31,12 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
     //community 게시물 좋아요 많은 순으로 정렬하고 id, 좋아요 수 반환 : Object[0] = id, Object[1] = 좋아요 수
     //타입을 구분하기 위해 앞에 타입도 반환
-    @Query("SELECT 'community', pl.community.id, COUNT(pl) as likeCount FROM PostLike pl GROUP BY pl.community.id " +
+    @Query("SELECT 'COMMUNITY', pl.community.id, COUNT(pl) as likeCount FROM PostLike pl GROUP BY pl.community.id " +
             "ORDER BY likeCount DESC")
     List<Object[]> findAllCommunityPostLikesTop();
 
     //retrospect 게시물 좋아요 많은 순으로 정렬
-    @Query("SELECT 'retrospect', pl.retrospect.id, COUNT(pl) as likeCount FROM PostLike pl GROUP BY pl.retrospect.id " +
+    @Query("SELECT 'RETROSPECT', pl.retrospect.id, COUNT(pl) as likeCount FROM PostLike pl GROUP BY pl.retrospect.id " +
             "ORDER BY likeCount DESC")
     List<Object[]> findAllRetrospectPostLikesTop();
 }

--- a/src/main/java/itstime/reflog/postlike/service/PopularScheduler.java
+++ b/src/main/java/itstime/reflog/postlike/service/PopularScheduler.java
@@ -18,9 +18,13 @@ public class PopularScheduler {
     private final PostLikeRepository postLikeRepository;
     private final PopularPostRepository popularPostRepository;
 
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 57 1 * * *")
     public void scheduledPopularPosts() {
 
+        //1. 이전에 있던 인기글 목록 지우기
+        popularPostRepository.deleteAll();
+
+        //2. 커뮤니티, 회고일지 좋아요 순으로 각각 가져오기
         List<Object[]> postLikesTop = new ArrayList<>(postLikeRepository.findAllCommunityPostLikesTop());
         postLikesTop.addAll(postLikeRepository.findAllRetrospectPostLikesTop());
 
@@ -30,7 +34,9 @@ public class PopularScheduler {
         //이 중 상위 세개만 가져옴
         List<Object[]> postLikesTopThree = postLikesTop.stream().limit(3).toList();
 
+        //가져온 데이터 저장
         for (Object[] postLike : postLikesTopThree) {
+            System.out.println("Post ID: " + (Long) postLike[1]);  //
             PopularPost popularPost = PopularPost.builder()
                     .postId((Long) postLike[1])
                     .postType(PostType.valueOf((String) postLike[0]))

--- a/src/main/java/itstime/reflog/postlike/service/PopularScheduler.java
+++ b/src/main/java/itstime/reflog/postlike/service/PopularScheduler.java
@@ -1,16 +1,41 @@
 package itstime.reflog.postlike.service;
 
+import itstime.reflog.postlike.domain.PopularPost;
+import itstime.reflog.postlike.domain.enums.PostType;
+import itstime.reflog.postlike.repository.PopularPostRepository;
 import itstime.reflog.postlike.repository.PostLikeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class PopularScheduler {
-    private final PostLikeService postLikeService;
+
+    private final PostLikeRepository postLikeRepository;
+    private final PopularPostRepository popularPostRepository;
+
     @Scheduled(cron = "0 0 0 * * *")
-    public void scheduledPopularPosts(Long memberId) {
-        postLikeService.getTopLikeCommunityPosts(memberId);
+    public void scheduledPopularPosts() {
+
+        List<Object[]> postLikesTop = new ArrayList<>(postLikeRepository.findAllCommunityPostLikesTop());
+        postLikesTop.addAll(postLikeRepository.findAllRetrospectPostLikesTop());
+
+        //좋아요 수인 object[1]이 Object 타입이기 떄문에 Long 타입으로 바꿔 준 후 비교 정렬
+        postLikesTop.sort((o1, o2) -> Long.compare((Long) o2[2], (Long) o1[2]));
+
+        //이 중 상위 세개만 가져옴
+        List<Object[]> postLikesTopThree = postLikesTop.stream().limit(3).toList();
+
+        for (Object[] postLike : postLikesTopThree) {
+            PopularPost popularPost = PopularPost.builder()
+                    .postId((Long) postLike[1])
+                    .postType(PostType.valueOf((String) postLike[0]))
+                    .build();
+            popularPostRepository.save(popularPost);
+        }
     }
 }

--- a/src/main/java/itstime/reflog/postlike/service/PopularScheduler.java
+++ b/src/main/java/itstime/reflog/postlike/service/PopularScheduler.java
@@ -1,0 +1,16 @@
+package itstime.reflog.postlike.service;
+
+import itstime.reflog.postlike.repository.PostLikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PopularScheduler {
+    private final PostLikeService postLikeService;
+    @Scheduled(cron = "0 0 0 * * *")
+    public void scheduledPopularPosts(Long memberId) {
+        postLikeService.getTopLikeCommunityPosts(memberId);
+    }
+}

--- a/src/main/java/itstime/reflog/postlike/service/PopularScheduler.java
+++ b/src/main/java/itstime/reflog/postlike/service/PopularScheduler.java
@@ -19,13 +19,13 @@ public class PopularScheduler {
     private final PostLikeRepository postLikeRepository;
     private final PopularPostRepository popularPostRepository;
 
-    @Scheduled(cron = "0 56 9 * * *")
+    @Scheduled(cron = "0 0 0 * * *")
     public void scheduledPopularPosts() {
 
         //1. 이전에 있던 인기글 목록 지우기
         popularPostRepository.deleteAll();
 
-        //2. 커뮤니티, 회고일지 좋아요 순으로 각각 가져오기
+        //2. 커뮤니티, 회고일지 좋아요 순으로 각각 가져와서 하나의 배열에 저장
         List<Object[]> postLikesTop = new ArrayList<>(postLikeRepository.findCommunityByPostLikeTop());
         postLikesTop.addAll(postLikeRepository.findARetrospectPostLikesTop());
 

--- a/src/main/java/itstime/reflog/postlike/service/PopularScheduler.java
+++ b/src/main/java/itstime/reflog/postlike/service/PopularScheduler.java
@@ -1,6 +1,7 @@
 package itstime.reflog.postlike.service;
 
 import itstime.reflog.postlike.domain.PopularPost;
+import itstime.reflog.postlike.domain.PostLike;
 import itstime.reflog.postlike.domain.enums.PostType;
 import itstime.reflog.postlike.repository.PopularPostRepository;
 import itstime.reflog.postlike.repository.PostLikeRepository;
@@ -18,15 +19,15 @@ public class PopularScheduler {
     private final PostLikeRepository postLikeRepository;
     private final PopularPostRepository popularPostRepository;
 
-    @Scheduled(cron = "0 57 1 * * *")
+    @Scheduled(cron = "0 56 9 * * *")
     public void scheduledPopularPosts() {
 
         //1. 이전에 있던 인기글 목록 지우기
         popularPostRepository.deleteAll();
 
         //2. 커뮤니티, 회고일지 좋아요 순으로 각각 가져오기
-        List<Object[]> postLikesTop = new ArrayList<>(postLikeRepository.findAllCommunityPostLikesTop());
-        postLikesTop.addAll(postLikeRepository.findAllRetrospectPostLikesTop());
+        List<Object[]> postLikesTop = new ArrayList<>(postLikeRepository.findCommunityByPostLikeTop());
+        postLikesTop.addAll(postLikeRepository.findARetrospectPostLikesTop());
 
         //좋아요 수인 object[1]이 Object 타입이기 떄문에 Long 타입으로 바꿔 준 후 비교 정렬
         postLikesTop.sort((o1, o2) -> Long.compare((Long) o2[2], (Long) o1[2]));
@@ -36,7 +37,7 @@ public class PopularScheduler {
 
         //가져온 데이터 저장
         for (Object[] postLike : postLikesTopThree) {
-            System.out.println("Post ID: " + (Long) postLike[1]);  //
+
             PopularPost popularPost = PopularPost.builder()
                     .postId((Long) postLike[1])
                     .postType(PostType.valueOf((String) postLike[0]))

--- a/src/main/java/itstime/reflog/postlike/service/PostLikeService.java
+++ b/src/main/java/itstime/reflog/postlike/service/PostLikeService.java
@@ -109,24 +109,19 @@ public class PostLikeService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(()-> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
 
-        List<Object[]> postLikesTop = new ArrayList<>(postLikeRepository.findAllCommunityPostLikesTop());
-        postLikesTop.addAll(postLikeRepository.findAllRetrospectPostLikesTop());
-
-        //좋아요 수인 object[1]이 Object 타입이기 떄문에 Long 타입으로 바꿔 준 후 비교 정렬
-        postLikesTop.sort((o1, o2) -> Long.compare((Long) o2[2], (Long) o1[2]));
-
-        //이 중 상위 세개만 가져옴
-        List<Object[]> postLikesTopThree = postLikesTop.stream().limit(3).toList();
 
         //반환하는 배열 초기화
         List<CommunityDto.CombinedCategoryResponse> combinedCategoryResponses = new ArrayList<>();
+
+
 
         //상위 세개에 대해 반환 객체로 만들어 배열에 저장
         for (int i = 0; i<postLikesTopThree.size(); i++){
             if (postLikesTopThree.get(i)[0].equals("community")) {
 
                 Community community = communityRepository.findById((Long) postLikesTopThree.get(i)[1])
-                        .orElseThrow(() -> new GeneralException(ErrorStatus._POST_NOT_FOUND));                String nickname = myPageRepository.findByMember(community.getMember())
+                        .orElseThrow(() -> new GeneralException(ErrorStatus._POST_NOT_FOUND));
+                String nickname = myPageRepository.findByMember(community.getMember())
                         .map(MyPage::getNickname)
                         .orElse("닉네임 없음");
                 //좋아요 있는지 없는지 플래그


### PR DESCRIPTION

## ✒️ 관련 이슈번호

- Closes #42 

## 🔑 Key Changes

1. 내용
    - PopularPost 엔티티를 만들어서 인기글 세개의 id 값과 PostType을 enum으로 저장하도록 함
    - 저장하는 서비스는 스케줄러를 달아 매일 자정마다 엔티티 초기화 + 새로운 인기글 저장 하도록 함
    - 회고일지와 커뮤니티 두개의 글 유형이 있기 때문에 db에서 가져올때 글 유형, 글 id값, 좋아요 수를 Object[]에 넣어서 가져옴
    - 처음에 post_id가 널이 들어가져서 db에서 가져올때 PostType에 따라 구분해서 가져옴

> 고민인게,, 이건 이전 인기글을 조회할 필요가 없어서 엔티티를 하나 더 만들 필요가 없다 생각해서 구글링해보니 글을 많이 없지만  대부분 다 redis에 캐싱해둠.. db에서 가져와 redis에 인기글 세개를 캐싱해 두는 방식.. 근데 memberId로 본인이 좋아요 눌렀는지 여부를 보내줘야하기 때문에 redis랑 db랑 동기화도 필요... 그래서 우선 엔티티를 하나 더 만드는 방식으로 했슴니다...

## 📸 Screenshot
<img width="1373" alt="스크린샷 2025-01-08 오전 9 59 57" src="https://github.com/user-attachments/assets/cfca9fc8-7da5-4e88-80bd-16abae95394a" />
<img width="1347" alt="스크린샷 2025-01-08 오전 10 00 16" src="https://github.com/user-attachments/assets/de55b6e2-5481-4f4c-b671-d1f172b67354" />
