### PR TITLE
Feature : 북마크 API 구현

### DIFF
--- a/src/main/java/itstime/reflog/common/code/status/ErrorStatus.java
+++ b/src/main/java/itstime/reflog/common/code/status/ErrorStatus.java
@@ -63,6 +63,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
 	//PostLike 관련 에러
 	_POSTLIKE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "POSTLIKE400", "올바른 PostType을 입력해주세요."),
+	_POSTLIKE_LIKETYPE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "POSTLIKE400", "올바른 liketype 입력해주세요."),
 	_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POSTLIKE404", "해당 게시물이 존재하지 않습니다"),
 	// comment 관련 에러
 	_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT404", "해당 댓글을 찾을 수 없습니다."),

--- a/src/main/java/itstime/reflog/community/controller/CommunityController.java
+++ b/src/main/java/itstime/reflog/community/controller/CommunityController.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import itstime.reflog.common.annotation.UserId;
 import itstime.reflog.mypage.dto.MyPageDto;
+import itstime.reflog.postlike.dto.PostLikeDto;
 import itstime.reflog.postlike.service.PostLikeService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -216,8 +217,9 @@ public class CommunityController {
     }
 
     @Operation(
-            summary = "커뮤니티 게시물 좋아요 API",
-            description = "커뮤니티 게시글 좋아요 버튼 누를때 사용하는 API입니다. postType에는 회고일지일 경우에는 RETROSPECT, 커뮤니티 게시물일 경우에는 COMMUNITY를 보내주면 됩니다.",
+            summary = "커뮤니티 게시물 좋아요/북마크 API",
+            description = "커뮤니티 게시글 좋아요/북마크 버튼 누를때 사용하는 API입니다. postType에는 회고일지일 경우에는 RETROSPECT, 커뮤니티 게시물일 경우에는 COMMUNITY를 보내주면 됩니다." +
+                    "likeType애는 북마크인 경우에는 BOOKMARK, 좋아요안 경우에는 LIKE 를 보내주면 됩니다.",
             responses = {
                     @ApiResponse(
                             responseCode = "200",
@@ -237,9 +239,9 @@ public class CommunityController {
     public ResponseEntity<CommonApiResponse<Void>> togglePostLike(
             @UserId String memberId,
             @PathVariable Long postId,
-            @RequestParam String postType
-    ) {
-        postLikeService.togglePostLike(memberId, postId, postType);
+            @RequestBody PostLikeDto.PostLikeSaveRequest dto
+            ) {
+        postLikeService.togglePostLike(memberId, postId, dto);
         return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
     }
 
@@ -289,7 +291,7 @@ public class CommunityController {
 	)
 	@GetMapping("/popular")
 	public ResponseEntity<CommonApiResponse<List<CommunityDto.CombinedCategoryResponse>>> getTopLikeCommunityPosts(
-			@RequestParam Long memberId
+            @UserId String memberId
 	)
 	{
 		List<CommunityDto.CombinedCategoryResponse> responses = postLikeService.getTopLikeCommunityPosts(memberId);

--- a/src/main/java/itstime/reflog/community/controller/CommunityController.java
+++ b/src/main/java/itstime/reflog/community/controller/CommunityController.java
@@ -323,4 +323,30 @@ public class CommunityController {
         List<MyPageDto.MyPagePostResponse> responses = communityService.getPostsByProfile(nickname);
         return ResponseEntity.ok(CommonApiResponse.onSuccess(responses));
     }
+
+    @Operation(
+            summary = "북마크 조회 API",
+            description = "커뮤니티 게시글 중 북마크 된 게시물들을 조회한다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "북마크된 게시물 조회 성공"
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "해당 회원을 찾을 수 없음"
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "서버 에러"
+                    )
+            }
+    )
+    @GetMapping("/bookmark")
+    public ResponseEntity<CommonApiResponse<List<PostLikeDto.BookMarkResponse>>> getBookmarks(
+            @UserId String memberId
+    ){
+        List<PostLikeDto.BookMarkResponse> responses = postLikeService.getBookmarks(memberId);
+        return ResponseEntity.ok(CommonApiResponse.onSuccess(responses));
+    }
 }

--- a/src/main/java/itstime/reflog/community/dto/CommunityDto.java
+++ b/src/main/java/itstime/reflog/community/dto/CommunityDto.java
@@ -44,8 +44,9 @@ public class CommunityDto {
 		private Integer understandingLevel;// Retrospect 전용
 		private Boolean isLike;
 		private int totalLike;
+		private Long totalComment;
 
-		public static CombinedCategoryResponse fromCommunity(Community community, String writer, Boolean isLike, Integer totalLike) {
+		public static CombinedCategoryResponse fromCommunity(Community community, String writer, Boolean isLike, Integer totalLike, Long totalComment) {
 			return CombinedCategoryResponse.builder()
 					.title(community.getTitle())
 					.content(community.getContent())
@@ -53,12 +54,13 @@ public class CommunityDto {
 					.postTypes(community.getPostTypes())
 					.learningTypes(community.getLearningTypes())
 					.isLike(isLike)
+					.totalComment(totalComment)
 					.totalLike(totalLike)
 					.writer(writer)
 					.build();
 		}
 
-		public static CombinedCategoryResponse fromRetrospect(Retrospect retrospect, String writer, Boolean isLike, Integer totalLike) {
+		public static CombinedCategoryResponse fromRetrospect(Retrospect retrospect, String writer, Boolean isLike, Integer totalLike, Long totalComment) {
 			return CombinedCategoryResponse.builder()
 					.title(retrospect.getTitle())
 					.createdDate(retrospect.getCreatedDate().atStartOfDay())
@@ -70,6 +72,7 @@ public class CommunityDto {
 					.understandingLevel(retrospect.getUnderstandingLevel())
 					.isLike(isLike)
 					.totalLike(totalLike)
+					.totalComment(totalComment)
 					.writer(writer)
 					.build();
 		}

--- a/src/main/java/itstime/reflog/community/service/CommunityService.java
+++ b/src/main/java/itstime/reflog/community/service/CommunityService.java
@@ -231,7 +231,9 @@ public class CommunityService {
                     //게시물마다 좋아요 총 갯수 반환
                     int totalLike = postLikeService.getSumCommunityPostLike(community);
 
-                    return CommunityDto.CombinedCategoryResponse.fromCommunity(community, nickname, isLike, totalLike);
+                    //게시물마다 댓글 수 반환
+                    Long totalComment = commentRepository.countByCommunity(community);
+                    return CommunityDto.CombinedCategoryResponse.fromCommunity(community, nickname, isLike, totalLike, totalComment);
                 })
                 .collect(Collectors.toList());
 
@@ -250,7 +252,10 @@ public class CommunityService {
                         //게시물마다 좋아요 총 갯수 반환
                         int totalLike = postLikeService.getSumRetrospectPostLike(retrospect);
 
-                        return CommunityDto.CombinedCategoryResponse.fromRetrospect(retrospect, nickname, isLike, totalLike);
+                        //게시물마다 댓글 수 반환
+                        Long totalComment = commentRepository.countByRetrospect(retrospect);
+
+                        return CommunityDto.CombinedCategoryResponse.fromRetrospect(retrospect, nickname, isLike, totalLike, totalComment);
                     })
                     .collect(Collectors.toList());
             responses.addAll(retrospectResponses); // 두 리스트 합치기(회고일지, 커뮤니티)
@@ -280,7 +285,9 @@ public class CommunityService {
                     //게시물마다 좋아요 총 갯수 반환
                     int totalLike = postLikeService.getSumCommunityPostLike(community);
 
-                    return CommunityDto.CombinedCategoryResponse.fromCommunity(community, nickname, isLike, totalLike);
+                    //게시물마다 댓글 수 반환
+                    Long totalComment = commentRepository.countByCommunity(community);
+                    return CommunityDto.CombinedCategoryResponse.fromCommunity(community, nickname, isLike, totalLike, totalComment);
                 })
                 .collect(Collectors.toList());
 
@@ -298,7 +305,10 @@ public class CommunityService {
                     //게시물마다 좋아요 총 갯수 반환
                     int totalLike = postLikeService.getSumRetrospectPostLike(retrospect);
 
-                    return CommunityDto.CombinedCategoryResponse.fromRetrospect(retrospect, nickname, isLike, totalLike);
+                    //게시물마다 댓글 수 반환
+                    Long totalComment = commentRepository.countByRetrospect(retrospect);
+
+                    return CommunityDto.CombinedCategoryResponse.fromRetrospect(retrospect, nickname, isLike, totalLike, totalComment);
                 })
                 .collect(Collectors.toList());
         responses.addAll(retrospectResponses); // 두 리스트 합치기(회고일지, 커뮤니티)
@@ -325,7 +335,10 @@ public class CommunityService {
                             //게시물마다 좋아요 총 갯수 반환
                             int totalLike = postLikeService.getSumRetrospectPostLike(retrospect);
 
-                            return CommunityDto.CombinedCategoryResponse.fromRetrospect(retrospect, nickname, isLike, totalLike);
+                            //게시물마다 댓글 수 반환
+                            Long totalComment = commentRepository.countByRetrospect(retrospect);
+
+                            return CommunityDto.CombinedCategoryResponse.fromRetrospect(retrospect, nickname, isLike, totalLike, totalComment);
                         })
                 .collect(Collectors.toList());
 
@@ -341,7 +354,10 @@ public class CommunityService {
                     //게시물마다 좋아요 총 갯수 반환
                     int totalLike = postLikeService.getSumCommunityPostLike(community);
 
-                    return CommunityDto.CombinedCategoryResponse.fromCommunity(community, nickname, isLike, totalLike);
+                    //게시물마다 댓글 수 반환
+                    Long totalComment = commentRepository.countByCommunity(community);
+
+                    return CommunityDto.CombinedCategoryResponse.fromCommunity(community, nickname, isLike, totalLike, totalComment);
                 })
                 .collect(Collectors.toList());
 

--- a/src/main/java/itstime/reflog/community/service/CommunityService.java
+++ b/src/main/java/itstime/reflog/community/service/CommunityService.java
@@ -226,7 +226,7 @@ public class CommunityService {
                             .orElse("닉네임 없음");
 
                     //좋아요 있는지 없는지 플래그
-                    Boolean isLike = postLikeRepository.findByMemberAndCommunity(member, community).isPresent();
+                    Boolean isLike = postLikeRepository.findLikeByMemberAndCommunity(member, community).isPresent();
 
                     //게시물마다 좋아요 총 갯수 반환
                     int totalLike = postLikeService.getSumCommunityPostLike(community);
@@ -245,7 +245,7 @@ public class CommunityService {
                                 .orElse("닉네임 없음");
 
                         //좋아요 있는지 없는지 플래그
-                        Boolean isLike = postLikeRepository.findByMemberAndRetrospect(member, retrospect).isPresent();
+                        Boolean isLike = postLikeRepository.findLikeByMemberAndRetrospect(member, retrospect).isPresent();
 
                         //게시물마다 좋아요 총 갯수 반환
                         int totalLike = postLikeService.getSumRetrospectPostLike(retrospect);
@@ -275,7 +275,7 @@ public class CommunityService {
                             .orElse("닉네임 없음");
 
                     //좋아요 있는지 없는지 플래그
-                    Boolean isLike = postLikeRepository.findByMemberAndCommunity(member, community).isPresent();
+                    Boolean isLike = postLikeRepository.findLikeByMemberAndCommunity(member, community).isPresent();
 
                     //게시물마다 좋아요 총 갯수 반환
                     int totalLike = postLikeService.getSumCommunityPostLike(community);
@@ -293,7 +293,7 @@ public class CommunityService {
                             .map(MyPage::getNickname)
                             .orElse("닉네임 없음");
                     //좋아요 있는지 없는지 플래그
-                    Boolean isLike = postLikeRepository.findByMemberAndRetrospect(member, retrospect).isPresent();
+                    Boolean isLike = postLikeRepository.findLikeByMemberAndRetrospect(member, retrospect).isPresent();
 
                     //게시물마다 좋아요 총 갯수 반환
                     int totalLike = postLikeService.getSumRetrospectPostLike(retrospect);
@@ -320,7 +320,7 @@ public class CommunityService {
                                     .map(MyPage::getNickname)
                                     .orElse("닉네임 없음");
                             //좋아요 있는지 없는지 플래그
-                            Boolean isLike = postLikeRepository.findByMemberAndRetrospect(member, retrospect).isPresent();
+                            Boolean isLike = postLikeRepository.findBookmarkByMemberAndRetrospect(member, retrospect).isPresent();
 
                             //게시물마다 좋아요 총 갯수 반환
                             int totalLike = postLikeService.getSumRetrospectPostLike(retrospect);
@@ -336,7 +336,7 @@ public class CommunityService {
                             .orElse("닉네임 없음");
 
                     //좋아요 있는지 없는지 플래그
-                    Boolean isLike = postLikeRepository.findByMemberAndCommunity(member, community).isPresent();
+                    Boolean isLike = postLikeRepository.findBookmarkByMemberAndCommunity(member, community).isPresent();
 
                     //게시물마다 좋아요 총 갯수 반환
                     int totalLike = postLikeService.getSumCommunityPostLike(community);

--- a/src/main/java/itstime/reflog/postlike/domain/PostLike.java
+++ b/src/main/java/itstime/reflog/postlike/domain/PostLike.java
@@ -36,6 +36,6 @@ public class PostLike {
     private PostType postType;
 
     @Enumerated(EnumType.STRING)
-    private LikeType likeType;
+    private LikeType likeType; //북마크인지 좋아요인지 구분하기 위해
 
 }

--- a/src/main/java/itstime/reflog/postlike/domain/PostLike.java
+++ b/src/main/java/itstime/reflog/postlike/domain/PostLike.java
@@ -3,6 +3,7 @@ package itstime.reflog.postlike.domain;
 import itstime.reflog.analysis.domain.enums.Period;
 import itstime.reflog.community.domain.Community;
 import itstime.reflog.member.domain.Member;
+import itstime.reflog.postlike.domain.enums.LikeType;
 import itstime.reflog.postlike.domain.enums.PostType;
 import itstime.reflog.retrospect.domain.Retrospect;
 import jakarta.persistence.*;
@@ -33,5 +34,8 @@ public class PostLike {
 
     @Enumerated(EnumType.STRING)
     private PostType postType;
+
+    @Enumerated(EnumType.STRING)
+    private LikeType likeType;
 
 }

--- a/src/main/java/itstime/reflog/postlike/domain/enums/LikeType.java
+++ b/src/main/java/itstime/reflog/postlike/domain/enums/LikeType.java
@@ -1,0 +1,5 @@
+package itstime.reflog.postlike.domain.enums;
+
+public enum LikeType {
+    BOOKMARK, LIKE
+}

--- a/src/main/java/itstime/reflog/postlike/dto/PostLikeDto.java
+++ b/src/main/java/itstime/reflog/postlike/dto/PostLikeDto.java
@@ -1,0 +1,14 @@
+package itstime.reflog.postlike.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class PostLikeDto {
+
+    @Getter
+    @AllArgsConstructor
+    public static class PostLikeSaveRequest{
+        private String postType;
+        private String likeType;
+    }
+}

--- a/src/main/java/itstime/reflog/postlike/dto/PostLikeDto.java
+++ b/src/main/java/itstime/reflog/postlike/dto/PostLikeDto.java
@@ -11,4 +11,11 @@ public class PostLikeDto {
         private String postType;
         private String likeType;
     }
+
+    @Getter
+    @AllArgsConstructor
+    public static class BookMarkResponse{
+        private String title;
+        private String content;
+    }
 }

--- a/src/main/java/itstime/reflog/postlike/dto/PostLikeDto.java
+++ b/src/main/java/itstime/reflog/postlike/dto/PostLikeDto.java
@@ -1,7 +1,10 @@
 package itstime.reflog.postlike.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import itstime.reflog.community.domain.Community;
+import itstime.reflog.postlike.domain.PostLike;
+import itstime.reflog.postlike.domain.enums.PostType;
+import itstime.reflog.retrospect.domain.Retrospect;
+import lombok.*;
 
 public class PostLikeDto {
 
@@ -13,9 +16,31 @@ public class PostLikeDto {
     }
 
     @Getter
+    @Builder
     @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static class BookMarkResponse{
         private String title;
         private String content;
+        PostType postType;
+        private Long postId;
+        private int progressLevel;
+
+        public static BookMarkResponse fromCommunityEntity(Community community){
+            return BookMarkResponse.builder()
+                    .title(community.getTitle())
+                    .content(community.getContent())
+                    .postId(community.getId())
+                    .postType(PostType.COMMUNITY)
+                    .build();
+        }
+        public static BookMarkResponse fromRetrospectEntity(Retrospect retrospect){
+            return BookMarkResponse.builder()
+                    .title(retrospect.getTitle())
+                    .postId(retrospect.getId())
+                    .progressLevel(retrospect.getProgressLevel())
+                    .postType(PostType.RETROSPECT)
+                    .build();
+        }
     }
 }

--- a/src/main/java/itstime/reflog/postlike/repository/PostLikeRepository.java
+++ b/src/main/java/itstime/reflog/postlike/repository/PostLikeRepository.java
@@ -14,16 +14,26 @@ import java.util.Optional;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
-    //널이 될수 있음
-    Optional<PostLike> findByMemberAndCommunity (Member member, Community community);
-    Optional<PostLike> findByMemberAndRetrospect (Member member, Retrospect retrospect);
+    //좋아요 가져오기,,, 널이 될수 있음
+    @Query("SELECT pl from PostLike pl WHERE pl.likeType = 'LIKE'")
+    Optional<PostLike> findLikeByMemberAndCommunity (Member member, Community community);
+
+    @Query("SELECT pl from PostLike pl WHERE pl.likeType = 'LIKE'")
+    Optional<PostLike> findLikeByMemberAndRetrospect (Member member, Retrospect retrospect);
+
+    //북마크 가져오기,, 널이 될수있음
+    @Query("SELECT pl from PostLike pl WHERE pl.likeType = 'BOOKMARK'")
+    Optional<PostLike> findBookmarkByMemberAndCommunity (Member member, Community community);
+
+    @Query("SELECT pl from PostLike pl WHERE pl.likeType = 'BOOKMARK'")
+    Optional<PostLike> findBookmarkByMemberAndRetrospect (Member member, Retrospect retrospect);
 
     //DB에서 community 좋아요 합 계산
-    @Query("SELECT COUNT(pl) FROM PostLike pl WHERE pl.community = :community")
+    @Query("SELECT COUNT(pl) FROM PostLike pl WHERE pl.community = :community AND pl.likeType = 'LIKE'")
     int countByCommunity(@Param("community") Community community);
 
     //DB에서 retrospect 좋아요 합 계산
-    @Query("SELECT COUNT(pl) FROM PostLike pl WHERE pl.retrospect = :retrospect")
+    @Query("SELECT COUNT(pl) FROM PostLike pl WHERE pl.retrospect = :retrospect AND pl.likeType = 'LIKE'")
     int countByRetrospect(@Param("retrospect") Retrospect retrospect);
 
     // 내가 좋아요를 누른 모든 커뮤니티 or 회고일지 글
@@ -31,12 +41,12 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
     //community 게시물 좋아요 많은 순으로 정렬하고 id, 좋아요 수 반환 : Object[0] = id, Object[1] = 좋아요 수
     //타입을 구분하기 위해 앞에 타입도 반환
-    @Query("SELECT 'COMMUNITY', pl.community.id, COUNT(pl) as likeCount FROM PostLike pl WHERE pl.postType = 'COMMUNITY' GROUP BY pl.community.id " +
+    @Query("SELECT 'COMMUNITY', pl.community.id, COUNT(pl) as likeCount FROM PostLike pl WHERE pl.postType = 'COMMUNITY' AND pl.likeType = 'LIKE' GROUP BY pl.community.id " +
             "ORDER BY likeCount DESC")
     List<Object[]> findCommunityByPostLikeTop();
 
     //retrospect 게시물 좋아요 많은 순으로 정렬
-    @Query("SELECT 'RETROSPECT', pl.retrospect.id, COUNT(pl) as likeCount FROM PostLike pl WHERE pl.postType = 'RETROSPECT' GROUP BY pl.retrospect.id " +
+    @Query("SELECT 'RETROSPECT', pl.retrospect.id, COUNT(pl) as likeCount FROM PostLike pl WHERE pl.postType = 'RETROSPECT' AND pl.likeType = 'LIKE' GROUP BY pl.retrospect.id " +
             "ORDER BY likeCount DESC")
     List<Object[]> findARetrospectPostLikesTop();
 }

--- a/src/main/java/itstime/reflog/postlike/repository/PostLikeRepository.java
+++ b/src/main/java/itstime/reflog/postlike/repository/PostLikeRepository.java
@@ -15,18 +15,19 @@ import java.util.Optional;
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
     //좋아요 가져오기,,, 널이 될수 있음
-    @Query("SELECT pl from PostLike pl WHERE pl.likeType = 'LIKE'")
-    Optional<PostLike> findLikeByMemberAndCommunity (Member member, Community community);
+    @Query("SELECT pl from PostLike pl WHERE pl.likeType = 'LIKE' AND pl.member = :member AND pl.community = :community")
+    Optional<PostLike> findLikeByMemberAndCommunity (@Param("member") Member member, @Param("community") Community community);
 
-    @Query("SELECT pl from PostLike pl WHERE pl.likeType = 'LIKE'")
-    Optional<PostLike> findLikeByMemberAndRetrospect (Member member, Retrospect retrospect);
+    @Query("SELECT pl from PostLike pl WHERE pl.likeType = 'LIKE' AND pl.member = :member AND pl.retrospect = :retrospect")
+    Optional<PostLike> findLikeByMemberAndRetrospect (@Param("member") Member member, @Param("retrospect") Retrospect retrospect);
 
-    //북마크 가져오기,, 널이 될수있음
-    @Query("SELECT pl from PostLike pl WHERE pl.likeType = 'BOOKMARK'")
-    Optional<PostLike> findBookmarkByMemberAndCommunity (Member member, Community community);
+    //북마크 가져오기
+    @Query("SELECT pl FROM PostLike pl WHERE pl.likeType = 'BOOKMARK' AND pl.member = :member AND pl.community = :community")
+    Optional<PostLike> findBookmarkByMemberAndCommunity(@Param("member") Member member, @Param("community") Community community);
 
-    @Query("SELECT pl from PostLike pl WHERE pl.likeType = 'BOOKMARK'")
-    Optional<PostLike> findBookmarkByMemberAndRetrospect (Member member, Retrospect retrospect);
+    @Query("SELECT pl FROM PostLike pl WHERE pl.likeType = 'BOOKMARK' AND pl.member = :member AND pl.retrospect = :retrospect")
+    Optional<PostLike> findBookmarkByMemberAndRetrospect(@Param("member") Member member, @Param("retrospect") Retrospect retrospect);
+
 
     //DB에서 community 좋아요 합 계산
     @Query("SELECT COUNT(pl) FROM PostLike pl WHERE pl.community = :community AND pl.likeType = 'LIKE'")
@@ -49,4 +50,7 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     @Query("SELECT 'RETROSPECT', pl.retrospect.id, COUNT(pl) as likeCount FROM PostLike pl WHERE pl.postType = 'RETROSPECT' AND pl.likeType = 'LIKE' GROUP BY pl.retrospect.id " +
             "ORDER BY likeCount DESC")
     List<Object[]> findARetrospectPostLikesTop();
+
+    @Query("SELECT pl from PostLike pl WHERE pl.likeType = 'BOOKMARK' AND pl.member = :member")
+    List<PostLike> findPostLikesByMember(@Param("member") Member member);
 }

--- a/src/main/java/itstime/reflog/postlike/service/PostLikeService.java
+++ b/src/main/java/itstime/reflog/postlike/service/PostLikeService.java
@@ -1,5 +1,6 @@
 package itstime.reflog.postlike.service;
 
+import itstime.reflog.comment.repository.CommentRepository;
 import itstime.reflog.common.code.status.ErrorStatus;
 import itstime.reflog.common.exception.GeneralException;
 import itstime.reflog.community.domain.Community;
@@ -40,6 +41,7 @@ public class PostLikeService {
     private final PopularPostRepository popularPostRepository;
     private final MemberServiceHelper memberServiceHelper;
     private final MissionService missionService;
+    private final CommentRepository commentRepository;
 
 
 
@@ -195,7 +197,10 @@ public class PostLikeService {
                         Boolean isLike = postLikeRepository.findLikeByMemberAndCommunity(member, community).isPresent();
                         int totalLike = getSumCommunityPostLike(community);
 
-                        return CommunityDto.CombinedCategoryResponse.fromCommunity(community, nickname, isLike, totalLike);
+                        //게시물마다 댓글 수 반환
+                        Long totalComment = commentRepository.countByCommunity(community);
+
+                        return CommunityDto.CombinedCategoryResponse.fromCommunity(community, nickname, isLike, totalLike, totalComment);
 
                     } else if (popularPost.getPostType() == PostType.RETROSPECT) {
                         Retrospect retrospect = retrospectRepository.findById(popularPost.getPostId())
@@ -206,7 +211,10 @@ public class PostLikeService {
                         Boolean isLike = postLikeRepository.findLikeByMemberAndRetrospect(member, retrospect).isPresent();
                         int totalLike = getSumRetrospectPostLike(retrospect);
 
-                        return CommunityDto.CombinedCategoryResponse.fromRetrospect(retrospect, nickname, isLike, totalLike);
+                        //게시물마다 댓글 수 반환
+                        Long totalComment = commentRepository.countByRetrospect(retrospect);
+
+                        return CommunityDto.CombinedCategoryResponse.fromRetrospect(retrospect, nickname, isLike, totalLike, totalComment);
 
                     } else {
                         throw new GeneralException(ErrorStatus._POST_NOT_FOUND);

--- a/src/main/java/itstime/reflog/postlike/service/PostLikeService.java
+++ b/src/main/java/itstime/reflog/postlike/service/PostLikeService.java
@@ -15,6 +15,7 @@ import itstime.reflog.mission.service.MissionService;
 import itstime.reflog.postlike.domain.PostLike;
 import itstime.reflog.postlike.domain.enums.LikeType;
 import itstime.reflog.postlike.domain.enums.PostType;
+import itstime.reflog.postlike.dto.PostLikeDto;
 import itstime.reflog.postlike.repository.PopularPostRepository;
 import itstime.reflog.postlike.repository.PostLikeRepository;
 import itstime.reflog.retrospect.domain.Retrospect;
@@ -44,7 +45,7 @@ public class PostLikeService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public void togglePostLike(String memberId, Long postId, String postType, String likeType){
+    public void togglePostLike(String memberId, Long postId, PostLikeDto.PostLikeSaveRequest dto){
         Member member = memberServiceHelper.findMemberByUuid(memberId);
 
         MyPage myPage = myPageRepository.findByMember(member)
@@ -53,12 +54,12 @@ public class PostLikeService {
         PostLike postLike;
 
         //1. 글 유형에 따라 다른 엔티티에서 테이블 가져오기
-        if (PostType.COMMUNITY == PostType.valueOf(postType)) {
+        if (PostType.COMMUNITY == PostType.valueOf(dto.getPostType())) {
             Community community = communityRepository.findById(postId)
                     .orElseThrow(() -> new GeneralException(ErrorStatus._COMMUNITY_NOT_FOUND));
 
             //좋아요인 경우
-            if (LikeType.LIKE == LikeType.valueOf(likeType)) {
+            if (LikeType.LIKE == LikeType.valueOf(dto.getLikeType())) {
                 //커뮤니티, 멤버 id와 일치하는 좋아요 가져오기
                 postLike = postLikeRepository.findLikeByMemberAndCommunity(member, community)
                         .orElse(null);
@@ -82,7 +83,7 @@ public class PostLikeService {
                     missionService.incrementMissionProgress(member.getId(), myPage, POWER_OF_HEART);
                 }
 
-            } else if (LikeType.BOOKMARK == LikeType.valueOf(likeType)) {
+            } else if (LikeType.BOOKMARK == LikeType.valueOf(dto.getLikeType())) {
                 //커뮤니티, 멤버 id와 일치하는 북마크 가져오기
                 postLike = postLikeRepository.findBookmarkByMemberAndCommunity(member, community)
                         .orElse(null);
@@ -106,11 +107,11 @@ public class PostLikeService {
                 throw new GeneralException(ErrorStatus._POSTLIKE_LIKETYPE_BAD_REQUEST);
             }
         }
-        else if (PostType.RETROSPECT == PostType.valueOf(postType)){
+        else if (PostType.RETROSPECT == PostType.valueOf(dto.getPostType())){
             Retrospect retrospect = retrospectRepository.findById(postId)
                     .orElseThrow(()-> new GeneralException(ErrorStatus._RETROSPECT_NOT_FOUND));
 
-            if (LikeType.LIKE == LikeType.valueOf(likeType)) {
+            if (LikeType.LIKE == LikeType.valueOf(dto.getLikeType())) {
 
                 //회고일지, 멤버 id와 일치하는 좋아요 가져오기
                 postLike = postLikeRepository.findLikeByMemberAndRetrospect(member, retrospect)
@@ -134,7 +135,7 @@ public class PostLikeService {
                     // 미션
                     missionService.incrementMissionProgress(member.getId(), myPage, POWER_OF_HEART);
                 }
-            } else if (LikeType.BOOKMARK == LikeType.valueOf(likeType)) { //북마크한경우
+            } else if (LikeType.BOOKMARK == LikeType.valueOf(dto.getLikeType())) { //북마크한경우
                 //커뮤니티, 멤버 id와 일치하는 북마크 가져오기
                 postLike = postLikeRepository.findBookmarkByMemberAndRetrospect(member, retrospect)
                         .orElse(null);

--- a/src/main/java/itstime/reflog/postlike/service/PostLikeService.java
+++ b/src/main/java/itstime/reflog/postlike/service/PostLikeService.java
@@ -223,4 +223,5 @@ public class PostLikeService {
 
         return combinedCategoryResponses;
     }
+
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #63 , #64 

## 🔑 Key Changes

1. 내용
    - 좋아요 엔티티에 북마크 데이터 추가
    - enum으로 북마크/좋아요 구분
    - 좋아요 처럼 누를때마다 db에 테이블 추가/삭제
    - 북마크 조회 API는 회고일지/커뮤니티 글 유형과 함께 반환 + 글 id
    - refactor: 댓글 총 갯수 추가해둠

## 📸 Screenshot
<img width="1376" alt="스크린샷 2025-01-09 오후 5 09 09" src="https://github.com/user-attachments/assets/ec7820cd-6e22-423c-8aa4-7a5ef9db4f01" />
<img width="1378" alt="스크린샷 2025-01-09 오후 5 09 40" src="https://github.com/user-attachments/assets/cefc58d2-afd2-48cb-976e-0d7efc97dffb" />
<img width="1367" alt="스크린샷 2025-01-09 오후 5 09 30" src="https://github.com/user-attachments/assets/99ba9f17-64a2-45a9-931e-c023c00593e3" />

