### PR TITLE
Feat : 알림 API 구현

### DIFF
--- a/src/main/java/itstime/reflog/analysis/service/MonthlyAnalysisService.java
+++ b/src/main/java/itstime/reflog/analysis/service/MonthlyAnalysisService.java
@@ -25,7 +25,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.Month;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -255,12 +254,12 @@ public class MonthlyAnalysisService {
         missionService.incrementMissionProgress(member.getId(), myPage, MONTHLY_REPORTER);
 
         // 알림
-        sendMonthlyNotification(analysis.getStartDate().getMonth(), member);
+        sendMonthlyNotification(analysis.getStartDate().getMonthValue(), member);
 
         return AnalysisDto.AnalysisDtoResponse.fromEntity(analysis);
     }
 
-    public void sendMonthlyNotification(Month month, Member member) {
+    public void sendMonthlyNotification(int month, Member member) {
         notificationService.sendNotification(
                 member.getId(),
                 month + "월 월간 분석보고서가 도착했어요!",

--- a/src/main/java/itstime/reflog/analysis/service/MonthlyAnalysisService.java
+++ b/src/main/java/itstime/reflog/analysis/service/MonthlyAnalysisService.java
@@ -263,7 +263,7 @@ public class MonthlyAnalysisService {
         notificationService.sendNotification(
                 member.getId(),
                 month + "월 월간 분석보고서가 도착했어요!",
-                NotificationType.MONTHLYANALYSIS
+                NotificationType.ANALYSIS
         );
     }
 }

--- a/src/main/java/itstime/reflog/analysis/service/MonthlyAnalysisService.java
+++ b/src/main/java/itstime/reflog/analysis/service/MonthlyAnalysisService.java
@@ -254,16 +254,17 @@ public class MonthlyAnalysisService {
         missionService.incrementMissionProgress(member.getId(), myPage, MONTHLY_REPORTER);
 
         // 알림
-        sendMonthlyNotification(analysis.getStartDate().getMonthValue(), member);
+        sendMonthlyNotification(analysis.getStartDate().getMonthValue(), member, date);
 
         return AnalysisDto.AnalysisDtoResponse.fromEntity(analysis);
     }
 
-    public void sendMonthlyNotification(int month, Member member) {
+    public void sendMonthlyNotification(int month, Member member, LocalDate date) {
         notificationService.sendNotification(
                 member.getId(),
                 month + "월 월간 분석보고서가 도착했어요!",
-                NotificationType.ANALYSIS
+                NotificationType.ANALYSIS,
+                "/api/v1/monthly-analysis?date=" + date
         );
     }
 }

--- a/src/main/java/itstime/reflog/analysis/service/MonthlyAnalysisService.java
+++ b/src/main/java/itstime/reflog/analysis/service/MonthlyAnalysisService.java
@@ -15,6 +15,8 @@ import itstime.reflog.member.service.MemberServiceHelper;
 import itstime.reflog.mission.service.MissionService;
 import itstime.reflog.mypage.domain.MyPage;
 import itstime.reflog.mypage.repository.MyPageRepository;
+import itstime.reflog.notification.domain.NotificationType;
+import itstime.reflog.notification.service.NotificationService;
 import itstime.reflog.retrospect.domain.Retrospect;
 import itstime.reflog.todolist.domain.Todolist;
 import jakarta.transaction.Transactional;
@@ -23,6 +25,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -46,8 +49,7 @@ public class MonthlyAnalysisService {
     private final MemberServiceHelper memberServiceHelper;
     private final MissionService missionService;
     private final MyPageRepository myPageRepository;
-
-
+    private final NotificationService notificationService;
 
 
     @Transactional
@@ -252,6 +254,17 @@ public class MonthlyAnalysisService {
 
         missionService.incrementMissionProgress(member.getId(), myPage, MONTHLY_REPORTER);
 
+        // 알림
+        sendMonthlyNotification(analysis.getStartDate().getMonth(), member);
+
         return AnalysisDto.AnalysisDtoResponse.fromEntity(analysis);
+    }
+
+    public void sendMonthlyNotification(Month month, Member member) {
+        notificationService.sendNotification(
+                member.getId(),
+                month + "월 월간 분석보고서가 도착했어요!",
+                NotificationType.MONTHLYANALYSIS
+        );
     }
 }

--- a/src/main/java/itstime/reflog/analysis/service/WeeklyAnalysisService.java
+++ b/src/main/java/itstime/reflog/analysis/service/WeeklyAnalysisService.java
@@ -268,7 +268,7 @@ public class WeeklyAnalysisService {
         notificationService.sendNotification(
                 member.getId(),
                 month + "월 " + weekOfMonth + "" + " 월간 분석보고서가 도착했어요!",
-                NotificationType.WEEKLYANALYSIS
+                NotificationType.ANALYSIS
         );
     }
 }

--- a/src/main/java/itstime/reflog/analysis/service/WeeklyAnalysisService.java
+++ b/src/main/java/itstime/reflog/analysis/service/WeeklyAnalysisService.java
@@ -255,12 +255,12 @@ public class WeeklyAnalysisService {
         missionService.incrementMissionProgress(member.getId(), myPage, WEEKLY_REPORTER);
 
         // 알림
-        sendWeeklyNotification(analysis.getStartDate(), member);
+        sendWeeklyNotification(analysis.getStartDate(), member, date);
 
         return AnalysisDto.AnalysisDtoResponse.fromEntity(analysis);
     }
 
-    public void sendWeeklyNotification(LocalDate startDate, Member member) {
+    public void sendWeeklyNotification(LocalDate startDate, Member member, LocalDate date) {
 
         String month = startDate.getMonth().toString();
         int weekOfMonth = startDate.get(ChronoField.ALIGNED_WEEK_OF_MONTH);
@@ -268,7 +268,8 @@ public class WeeklyAnalysisService {
         notificationService.sendNotification(
                 member.getId(),
                 month + "월 " + weekOfMonth + "" + " 월간 분석보고서가 도착했어요!",
-                NotificationType.ANALYSIS
+                NotificationType.ANALYSIS,
+                "/api/v1/weekly-analysis?date=" + date
         );
     }
 }

--- a/src/main/java/itstime/reflog/analysis/service/WeeklyAnalysisService.java
+++ b/src/main/java/itstime/reflog/analysis/service/WeeklyAnalysisService.java
@@ -15,6 +15,8 @@ import itstime.reflog.member.service.MemberServiceHelper;
 import itstime.reflog.mission.service.MissionService;
 import itstime.reflog.mypage.domain.MyPage;
 import itstime.reflog.mypage.repository.MyPageRepository;
+import itstime.reflog.notification.domain.NotificationType;
+import itstime.reflog.notification.service.NotificationService;
 import itstime.reflog.retrospect.domain.Retrospect;
 import itstime.reflog.todolist.domain.Todolist;
 import jakarta.transaction.Transactional;
@@ -23,6 +25,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +49,7 @@ public class WeeklyAnalysisService {
     private final MemberServiceHelper memberServiceHelper;
     private final MissionService missionService;
     private final MyPageRepository myPageRepository;
+    private final NotificationService notificationService;
 
 
 
@@ -250,7 +254,21 @@ public class WeeklyAnalysisService {
 
         missionService.incrementMissionProgress(member.getId(), myPage, WEEKLY_REPORTER);
 
+        // 알림
+        sendWeeklyNotification(analysis.getStartDate(), member);
+
         return AnalysisDto.AnalysisDtoResponse.fromEntity(analysis);
     }
 
+    public void sendWeeklyNotification(LocalDate startDate, Member member) {
+
+        String month = startDate.getMonth().toString();
+        int weekOfMonth = startDate.get(ChronoField.ALIGNED_WEEK_OF_MONTH);
+
+        notificationService.sendNotification(
+                member.getId(),
+                month + "월 " + weekOfMonth + "" + " 월간 분석보고서가 도착했어요!",
+                NotificationType.WEEKLYANALYSIS
+        );
+    }
 }

--- a/src/main/java/itstime/reflog/comment/service/CommentService.java
+++ b/src/main/java/itstime/reflog/comment/service/CommentService.java
@@ -96,9 +96,9 @@ public class CommentService {
         // 7. 알림
         if (retrospect == null) {
             assert community != null;
-            sendCommunityCommentLikeNotification(community, member);
+            sendCommunityCommentNotification(community, member);
         }else{
-            sendRetrospectCommentLikeNotification(retrospect, member);
+            sendRetrospectCommentNotification(retrospect, member);
         }
     }
 
@@ -150,7 +150,7 @@ public class CommentService {
         }
     }
 
-    public void sendCommunityCommentLikeNotification(Community community, Member sender) {
+    public void sendCommunityCommentNotification(Community community, Member sender) {
         Member receiver = community.getMember(); // 알림 받는 자
 
         String title = community.getTitle(); // 글 제목
@@ -159,12 +159,12 @@ public class CommentService {
 
         notificationService.sendNotification(
                 receiver.getId(),
-                nickname + " 님이 " + title + "에 좋아요를 눌렀습니다.",
+                nickname + " 님이 " + title + "에 댓글을 남겼습니다.",
                 NotificationType.POSTLIKE
         );
     }
 
-    public void sendRetrospectCommentLikeNotification(Retrospect retrospect, Member sender) {
+    public void sendRetrospectCommentNotification(Retrospect retrospect, Member sender) {
         Member receiver = retrospect.getMember(); // 알림 받는 자
 
         String title = retrospect.getTitle(); // 글 제목

--- a/src/main/java/itstime/reflog/comment/service/CommentService.java
+++ b/src/main/java/itstime/reflog/comment/service/CommentService.java
@@ -174,7 +174,7 @@ public class CommentService {
         notificationService.sendNotification(
                 receiver.getId(),
                 nickname + " 님이 " + title + "에 댓글을 남겼습니다.",
-                NotificationType.POSTLIKE
+                NotificationType.COMMENT
         );
     }
 }

--- a/src/main/java/itstime/reflog/comment/service/CommentService.java
+++ b/src/main/java/itstime/reflog/comment/service/CommentService.java
@@ -160,7 +160,7 @@ public class CommentService {
         notificationService.sendNotification(
                 receiver.getId(),
                 nickname + " 님이 " + title + "에 댓글을 남겼습니다.",
-                NotificationType.POSTLIKE
+                NotificationType.COMMUNITY
         );
     }
 
@@ -174,7 +174,7 @@ public class CommentService {
         notificationService.sendNotification(
                 receiver.getId(),
                 nickname + " 님이 " + title + "에 댓글을 남겼습니다.",
-                NotificationType.COMMENT
+                NotificationType.COMMUNITY
         );
     }
 }

--- a/src/main/java/itstime/reflog/comment/service/CommentService.java
+++ b/src/main/java/itstime/reflog/comment/service/CommentService.java
@@ -160,7 +160,8 @@ public class CommentService {
         notificationService.sendNotification(
                 receiver.getId(),
                 nickname + " 님이 " + title + "에 댓글을 남겼습니다.",
-                NotificationType.COMMUNITY
+                NotificationType.COMMUNITY,
+                "/api/v1/communities/" + community.getId()
         );
     }
 
@@ -174,7 +175,8 @@ public class CommentService {
         notificationService.sendNotification(
                 receiver.getId(),
                 nickname + " 님이 " + title + "에 댓글을 남겼습니다.",
-                NotificationType.COMMUNITY
+                NotificationType.COMMUNITY,
+                "/api/v1/retrospect/?retrospectId=" + retrospect.getId()
         );
     }
 }

--- a/src/main/java/itstime/reflog/common/code/status/ErrorStatus.java
+++ b/src/main/java/itstime/reflog/common/code/status/ErrorStatus.java
@@ -68,7 +68,10 @@ public enum ErrorStatus implements BaseErrorCode {
 	_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT404", "해당 댓글을 찾을 수 없습니다."),
 	_PARENT_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT404", "해당 부모 댓글을 찾을 수 없습니다."),
 	_INVALID_POST_TYPE(HttpStatus.NOT_FOUND, "COMMENT404", "해당 댓글에 대한 게시글의 타입이 존재하지 않습니다."),
-	// notification 관련 에러
+	// NotificationSettings 관련 에러
+	_NOTIFICATIONSETTINGS_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATIONSETTINGS404", "해당 알림 설정이 존재하지 않습니다"),
+
+	// Notification 관련 에러
 	_DELAY(HttpStatus.NOT_FOUND, "NOTIFICATION404", "시작시간이 더 미래일 수는 없습니다."),
 	_NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION404", "해당 알림이 존재하지 않습니다")
 	;

--- a/src/main/java/itstime/reflog/common/code/status/ErrorStatus.java
+++ b/src/main/java/itstime/reflog/common/code/status/ErrorStatus.java
@@ -67,7 +67,11 @@ public enum ErrorStatus implements BaseErrorCode {
 	// comment 관련 에러
 	_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT404", "해당 댓글을 찾을 수 없습니다."),
 	_PARENT_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT404", "해당 부모 댓글을 찾을 수 없습니다."),
-	_INVALID_POST_TYPE(HttpStatus.NOT_FOUND, "COMMENT404", "해당 댓글에 대한 게시글의 타입이 존재하지 않습니다.");
+	_INVALID_POST_TYPE(HttpStatus.NOT_FOUND, "COMMENT404", "해당 댓글에 대한 게시글의 타입이 존재하지 않습니다."),
+	// notification 관련 에러
+	_DELAY(HttpStatus.NOT_FOUND, "NOTIFICATION404", "시작시간이 더 미래일 수는 없습니다."),
+	_NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION404", "해당 알림이 존재하지 않습니다")
+	;
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/itstime/reflog/config/SchedulingConfig.java
+++ b/src/main/java/itstime/reflog/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package itstime.reflog.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/itstime/reflog/mission/domain/Badge.java
+++ b/src/main/java/itstime/reflog/mission/domain/Badge.java
@@ -1,26 +1,32 @@
 package itstime.reflog.mission.domain;
 
 public enum Badge {
-    FIRST_MEETING(1), // 첫 만남
-    RETROSPECTIVE_GURU(7), // 회고쟁이
-    RETROSPECTIVE_MANIA(30), // 회고매니아
-    KING_OF_COMMUNICATION(3), // 소통의 왕
-    WEEKLY_REPORTER(2), // 주간 리포터
-    MONTHLY_REPORTER(2), // 월간 리포터
-    HABIT_STARTER(5), // 습관의 시작
-    MOTIVATION_STARTER(3), // 동기의 시작
-    POWER_OF_HEART(5), // 하트의 힘
-    RETROSPECTIVE_STARTER(1), // 회고스타터
-    RETROSPECTIVE_REVIEWER(2), // 회고리뷰어
-    POWER_OF_COMMENTS(3); // 댓글의 힘
+    FIRST_MEETING(1, "첫 만남"),
+    RETROSPECTIVE_GURU(7, "회고쟁이"),
+    RETROSPECTIVE_MANIA(30, "회고매니아"),
+    KING_OF_COMMUNICATION(3, "소통의 왕"),
+    WEEKLY_REPORTER(2, "주간 리포터"),
+    MONTHLY_REPORTER(2, "월간 리포터"),
+    HABIT_STARTER(5, "습관의 시작"),
+    MOTIVATION_STARTER(3, "동기의 시작"),
+    POWER_OF_HEART(5, "하트의 힘"),
+    RETROSPECTIVE_STARTER(1, "회고스타터"),
+    RETROSPECTIVE_REVIEWER(2, "회고리뷰어"),
+    POWER_OF_COMMENTS(3, "댓글의 힘");
 
-    Badge(int targetNum) {
-        this.targetNum = targetNum;
-    }
     private final int targetNum;
+    private final String koreanName;
+
+    Badge(int targetNum, String koreanName) {
+        this.targetNum = targetNum;
+        this.koreanName = koreanName;
+    }
 
     public int getTargetNum() {
         return targetNum;
     }
-}
 
+    public String getKoreanName() {
+        return koreanName;
+    }
+}

--- a/src/main/java/itstime/reflog/mission/service/BadgeService.java
+++ b/src/main/java/itstime/reflog/mission/service/BadgeService.java
@@ -37,7 +37,8 @@ public class BadgeService {
         notificationService.sendNotification(
                 memberId,
                 badge.getKoreanName() + " 배지를 획득했어요!",
-                NotificationType.BADGE
+                NotificationType.BADGE,
+                "/api/v1/mypage/badges"
         );
     }
 }

--- a/src/main/java/itstime/reflog/mission/service/BadgeService.java
+++ b/src/main/java/itstime/reflog/mission/service/BadgeService.java
@@ -36,7 +36,7 @@ public class BadgeService {
 
         notificationService.sendNotification(
                 memberId,
-                "축하합니다! '" + badge.name() + "' 배지를 획득하셨습니다.",
+                badge.getKoreanName() + " 배지를 획득했어요!",
                 NotificationType.MISSION
         );
     }

--- a/src/main/java/itstime/reflog/mission/service/BadgeService.java
+++ b/src/main/java/itstime/reflog/mission/service/BadgeService.java
@@ -37,7 +37,7 @@ public class BadgeService {
         notificationService.sendNotification(
                 memberId,
                 badge.getKoreanName() + " 배지를 획득했어요!",
-                NotificationType.MISSION
+                NotificationType.BADGE
         );
     }
 }

--- a/src/main/java/itstime/reflog/mission/service/MissionService.java
+++ b/src/main/java/itstime/reflog/mission/service/MissionService.java
@@ -82,7 +82,8 @@ public class MissionService {
         notificationService.sendNotification(
                 memberId,
                 content,
-                NotificationType.BADGE
+                NotificationType.BADGE,
+                "/api/v1/mypage/badges"
         );
     }
 }

--- a/src/main/java/itstime/reflog/mission/service/MissionService.java
+++ b/src/main/java/itstime/reflog/mission/service/MissionService.java
@@ -6,6 +6,8 @@ import itstime.reflog.mission.domain.Badge;
 import itstime.reflog.mission.domain.UserMission;
 import itstime.reflog.mission.repository.UserMissionRepository;
 import itstime.reflog.mypage.domain.MyPage;
+import itstime.reflog.notification.domain.NotificationType;
+import itstime.reflog.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +18,8 @@ public class MissionService {
 
     private final UserMissionRepository userMissionRepository;
     private final BadgeService badgeService;
+    private final NotificationService notificationService;
+
 
     @Transactional
     public void incrementMissionProgress(Long memberId, MyPage myPage, Badge badge) {
@@ -27,9 +31,58 @@ public class MissionService {
         userMission.incrementProgress();
         userMissionRepository.save(userMission);
 
-        // 3. 유저 미션 완료 여부 확인 및 배지 지급
+        // 3. 유저 미션 처음
+        if (badge != Badge.FIRST_MEETING && badge != Badge.RETROSPECTIVE_STARTER) {
+            if (badge == Badge.RETROSPECTIVE_MANIA && userMission.getProgressCount() == 10) {
+                sendMissionNotification(memberId, badge, userMission);
+            } else if (badge == Badge.RETROSPECTIVE_GURU && userMission.getProgressCount() == 3) {
+                sendMissionNotification(memberId, badge, userMission);
+            } else if (userMission.getProgressCount() == 1) {
+                sendMissionNotification(memberId, badge, userMission);
+            }
+        }
+
+        // 4. 유저 미션 완료 여부 확인 및 배지 지급
         if (userMission.isCompleted()) {
             badgeService.awardBadge(memberId, myPage, badge);
         }
+    }
+
+    public void sendMissionNotification(Long memberId, Badge badge, UserMission userMission) {
+        String content = null;
+
+        if (badge == Badge.RETROSPECTIVE_MANIA && userMission.getProgressCount() == 1) {
+            return;
+        } else if (badge == Badge.RETROSPECTIVE_GURU && userMission.getProgressCount() == 1) {
+            return;
+        }
+
+        if (badge.equals(Badge.KING_OF_COMMUNICATION)) {
+            content = "최초로 커뮤니티에 글을 작성했네요!";
+        } else if (badge.equals(Badge.RETROSPECTIVE_MANIA)) {
+            content = "회고일지를 10회 작성했네요!";
+        } else if (badge.equals(Badge.POWER_OF_HEART)) {
+            content = "최초로 좋아요를 눌렀네요!";
+        } else if (badge.equals(Badge.RETROSPECTIVE_REVIEWER)) {
+            content = "최초로 작성한 회고일지를 열람했네요!";
+        } else if (badge.equals(Badge.HABIT_STARTER)) {
+            content = "최초로 투두리스트를 작성했네요!";
+        } else if (badge.equals(Badge.RETROSPECTIVE_GURU)) {
+            content = "회고일지를 3회 작성했네요!";
+        } else if (badge.equals(Badge.MONTHLY_REPORTER)) {
+            content = "최초로 월간 보고서를 열람했네요!";
+        } else if (badge.equals(Badge.WEEKLY_REPORTER)) {
+            content = "최초로 주간 보고서를 열람했네요!";
+        } else if (badge.equals(Badge.POWER_OF_COMMENTS)) {
+            content = "최초의 댓글을 작성했네요!";
+        } else {
+            content = "회고일지를 최초로 공유했네요!";
+        }
+
+        notificationService.sendNotification(
+                memberId,
+                content,
+                NotificationType.BADGE
+        );
     }
 }

--- a/src/main/java/itstime/reflog/mypage/controller/NotificationSettingsController.java
+++ b/src/main/java/itstime/reflog/mypage/controller/NotificationSettingsController.java
@@ -1,0 +1,82 @@
+package itstime.reflog.mypage.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import itstime.reflog.common.CommonApiResponse;
+import itstime.reflog.common.annotation.UserId;
+import itstime.reflog.mypage.dto.NotificationSettingsDto;
+import itstime.reflog.mypage.service.NotificationSettingsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "NotificationSettings API", description = "알림설정에 대한 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notifications/settings")
+public class NotificationSettingsController {
+
+    private final NotificationSettingsService notificationSettingsService;
+
+    @Operation(
+            summary = "마이페이지 내 알림 설정 수정 API",
+            description = "특정 회원에 해당하는 마이페이지 내 알림 설정을 수정합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "마이페이지 내  알림 설정 수정 성공",
+                            content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "해당 회원 또는 마이페이지 내  알림 설정을 찾을 수 없음",
+                            content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "서버 에러",
+                            content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+                    )
+            }
+    )
+    @PutMapping("")
+    public ResponseEntity<CommonApiResponse<Void>> updateSettings(
+            @UserId String memberId,
+            @RequestBody NotificationSettingsDto.NotificationSettingsRequest request
+    ) {
+        notificationSettingsService.updateNotificationSettings(memberId, request.getPreferences(), request.isAllNotificationsEnabled());
+        return ResponseEntity.ok(CommonApiResponse.onSuccess(null));
+    }
+
+    @Operation(
+            summary = "마이페이지 내 알림 설정 조회 API",
+            description = "특정 회원에 해당하는 마이페이지 내 알림 설정을 조회합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "마이페이지 내  알림 설정 조회 성공",
+                            content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "해당 회원 또는 마이페이지 내  알림 설정을 찾을 수 없음",
+                            content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "서버 에러",
+                            content = @Content(schema = @Schema(implementation = CommonApiResponse.class))
+                    )
+            }
+    )
+    @GetMapping("")
+    public ResponseEntity<CommonApiResponse<NotificationSettingsDto.NotificationSettingsResponse>> getSettings(
+            @UserId String memberId
+    ) {
+        NotificationSettingsDto.NotificationSettingsResponse response = notificationSettingsService.getSettings(memberId);
+        return ResponseEntity.ok(CommonApiResponse.onSuccess(response));
+    }
+}

--- a/src/main/java/itstime/reflog/mypage/domain/NotificationSettings.java
+++ b/src/main/java/itstime/reflog/mypage/domain/NotificationSettings.java
@@ -1,0 +1,37 @@
+package itstime.reflog.mypage.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import itstime.reflog.member.domain.Member;
+import itstime.reflog.notification.domain.NotificationType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+@AllArgsConstructor
+public class NotificationSettings {
+
+    @Id
+    @Column(name = "notificationSettings_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    @JsonIgnore
+    private Member member;
+
+    @ElementCollection
+    @CollectionTable(name = "notification_settings_map", joinColumns = @JoinColumn(name = "settings_id"))
+    @MapKeyEnumerated(EnumType.STRING)
+    @Column(name = "is_enabled")
+    private Map<NotificationType, Boolean> notificationPreferences = new EnumMap<>(NotificationType.class);
+
+    private boolean allNotificationsEnabled = true;
+}

--- a/src/main/java/itstime/reflog/mypage/dto/NotificationSettingsDto.java
+++ b/src/main/java/itstime/reflog/mypage/dto/NotificationSettingsDto.java
@@ -1,0 +1,26 @@
+package itstime.reflog.mypage.dto;
+
+import itstime.reflog.notification.domain.NotificationType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+public class NotificationSettingsDto {
+
+    @Getter
+    @Setter
+    public static class NotificationSettingsRequest {
+        private boolean allNotificationsEnabled;
+        private Map<NotificationType, Boolean> preferences;
+    }
+
+
+    @Getter
+    @AllArgsConstructor
+    public static class NotificationSettingsResponse {
+        private boolean allNotificationsEnabled;
+        private Map<NotificationType, Boolean> preferences;
+    }
+}

--- a/src/main/java/itstime/reflog/mypage/repository/NotificationSettingsRepository.java
+++ b/src/main/java/itstime/reflog/mypage/repository/NotificationSettingsRepository.java
@@ -1,0 +1,10 @@
+package itstime.reflog.mypage.repository;
+
+import itstime.reflog.mypage.domain.NotificationSettings;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface NotificationSettingsRepository extends JpaRepository<NotificationSettings, Long> {
+    Optional<NotificationSettings> findByMemberId(Long memberId);
+}

--- a/src/main/java/itstime/reflog/mypage/service/NotificationSettingsService.java
+++ b/src/main/java/itstime/reflog/mypage/service/NotificationSettingsService.java
@@ -1,0 +1,79 @@
+package itstime.reflog.mypage.service;
+
+import itstime.reflog.common.code.status.ErrorStatus;
+import itstime.reflog.common.exception.GeneralException;
+import itstime.reflog.member.domain.Member;
+import itstime.reflog.member.service.MemberServiceHelper;
+import itstime.reflog.mypage.domain.NotificationSettings;
+import itstime.reflog.mypage.dto.NotificationSettingsDto;
+import itstime.reflog.mypage.repository.NotificationSettingsRepository;
+import itstime.reflog.notification.domain.NotificationType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationSettingsService {
+    private final NotificationSettingsRepository notificationSettingsRepository;
+    private final MemberServiceHelper memberServiceHelper;
+
+    @Transactional
+    public void updateNotificationSettings(String memberId, Map<NotificationType, Boolean> preferences, boolean allNotificationsEnabled) {
+        // 1. 멤버 조회
+        Member member = memberServiceHelper.findMemberByUuid(memberId);
+
+        // 2. 알림 설정 생성&조회
+        NotificationSettings settings = notificationSettingsRepository.findByMemberId(member.getId())
+                .orElseGet(() -> createDefaultSettings(member));
+
+        // 3. 전체 알림 설정 업데이트
+        settings.setAllNotificationsEnabled(allNotificationsEnabled);
+
+        // 4. 각 알림 설정 업데이트
+        if (preferences != null) {
+            settings.getNotificationPreferences().putAll(preferences);
+        }
+
+        notificationSettingsRepository.save(settings);
+    }
+
+    @Transactional
+    public NotificationSettingsDto.NotificationSettingsResponse getSettings(String memberId) {
+        // 1. 멤버 조회
+        Member member = memberServiceHelper.findMemberByUuid(memberId);
+
+        // 2. 알림 설정 조회
+        NotificationSettings settings =  notificationSettingsRepository.findByMemberId(member.getId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._NOTIFICATIONSETTINGS_NOT_FOUND));
+
+        System.out.println("Settings Found: " + settings);
+        System.out.println("All Notifications Enabled: " + settings.isAllNotificationsEnabled());
+        System.out.println("Preferences: " + settings.getNotificationPreferences());
+
+
+        return new NotificationSettingsDto.NotificationSettingsResponse(
+                settings.isAllNotificationsEnabled(),
+                settings.getNotificationPreferences()
+        );
+    }
+
+    private NotificationSettings createDefaultSettings(Member member) {
+        // 1. 알림 설정 생성
+        NotificationSettings settings = new NotificationSettings();
+        settings.setMember(member);
+        settings.setAllNotificationsEnabled(true);
+
+        // 2. 알림 설정 기본값 설정
+        Map<NotificationType, Boolean> defaultPreferences = new EnumMap<>(NotificationType.class);
+        for (NotificationType type : NotificationType.values()) {
+            defaultPreferences.put(type, true);
+        }
+        settings.setNotificationPreferences(defaultPreferences);
+
+        return notificationSettingsRepository.save(settings);
+    }
+}

--- a/src/main/java/itstime/reflog/notification/controller/NotificationController.java
+++ b/src/main/java/itstime/reflog/notification/controller/NotificationController.java
@@ -1,10 +1,10 @@
 package itstime.reflog.notification.controller;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import itstime.reflog.common.annotation.UserId;
 import itstime.reflog.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -17,8 +17,10 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
-    @GetMapping("/subscribe/{memberId}")
-    public SseEmitter subscribe(@PathVariable Long memberId) {
+    @GetMapping("/subscribe")
+    public SseEmitter subscribe(
+            @UserId String memberId
+    ) {
         return notificationService.subscribe(memberId);
     }
 }

--- a/src/main/java/itstime/reflog/notification/domain/Notification.java
+++ b/src/main/java/itstime/reflog/notification/domain/Notification.java
@@ -24,6 +24,8 @@ public class Notification {
     @Column(nullable = false)
     private String message;
 
+    private String url;
+
     @Column(nullable = false)
     private LocalDateTime createdAt;
 

--- a/src/main/java/itstime/reflog/notification/domain/NotificationType.java
+++ b/src/main/java/itstime/reflog/notification/domain/NotificationType.java
@@ -5,5 +5,6 @@ public enum NotificationType {
     POST,
     COMMENT,
     POSTLIKE,
-    MONTHLYANALYSIS
+    MONTHLYANALYSIS,
+    WEEKLYANALYSIS
 }

--- a/src/main/java/itstime/reflog/notification/domain/NotificationType.java
+++ b/src/main/java/itstime/reflog/notification/domain/NotificationType.java
@@ -1,11 +1,9 @@
 package itstime.reflog.notification.domain;
 
 public enum NotificationType {
-    BADGE,
     POST,
-    COMMENT,
-    POSTLIKE,
-    MONTHLYANALYSIS,
-    WEEKLYANALYSIS,
-    SCHEDULE
+    COMMUNITY,
+    ANALYSIS,
+    SCHEDULE,
+    BADGE
 }

--- a/src/main/java/itstime/reflog/notification/domain/NotificationType.java
+++ b/src/main/java/itstime/reflog/notification/domain/NotificationType.java
@@ -3,5 +3,6 @@ package itstime.reflog.notification.domain;
 public enum NotificationType {
     MISSION,
     POST,
-    COMMENT
+    COMMENT,
+    POSTLIKE
 }

--- a/src/main/java/itstime/reflog/notification/domain/NotificationType.java
+++ b/src/main/java/itstime/reflog/notification/domain/NotificationType.java
@@ -1,8 +1,9 @@
 package itstime.reflog.notification.domain;
 
 public enum NotificationType {
-    MISSION,
+    BADGE,
     POST,
     COMMENT,
-    POSTLIKE
+    POSTLIKE,
+    MONTHLYANALYSIS
 }

--- a/src/main/java/itstime/reflog/notification/domain/NotificationType.java
+++ b/src/main/java/itstime/reflog/notification/domain/NotificationType.java
@@ -6,5 +6,6 @@ public enum NotificationType {
     COMMENT,
     POSTLIKE,
     MONTHLYANALYSIS,
-    WEEKLYANALYSIS
+    WEEKLYANALYSIS,
+    SCHEDULE
 }

--- a/src/main/java/itstime/reflog/notification/dto/NotificationDto.java
+++ b/src/main/java/itstime/reflog/notification/dto/NotificationDto.java
@@ -1,0 +1,16 @@
+package itstime.reflog.notification.dto;
+
+import itstime.reflog.notification.domain.NotificationType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class NotificationDto {
+
+    @Getter
+    @AllArgsConstructor
+    public static class NotificationResponse {
+        private String message;
+        private NotificationType type;
+        private String url;
+    }
+}

--- a/src/main/java/itstime/reflog/notification/repository/NotificationRepository.java
+++ b/src/main/java/itstime/reflog/notification/repository/NotificationRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     List<Notification> findByMemberId(Long memberId);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/itstime/reflog/notification/service/NotificationService.java
+++ b/src/main/java/itstime/reflog/notification/service/NotificationService.java
@@ -4,6 +4,7 @@ import itstime.reflog.member.domain.Member;
 import itstime.reflog.member.service.MemberServiceHelper;
 import itstime.reflog.notification.domain.Notification;
 import itstime.reflog.notification.domain.NotificationType;
+import itstime.reflog.notification.dto.NotificationDto;
 import itstime.reflog.notification.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -37,11 +38,12 @@ public class NotificationService {
         return emitter;
     }
 
-    public void sendNotification(Long memberId, String message, NotificationType type) {
+    public void sendNotification(Long memberId, String message, NotificationType type, String url) {
         // Save the notification to the database
         Notification notification = Notification.builder()
                 .memberId(memberId)
                 .message(message)
+                .url(url)
                 .type(type)
                 .createdAt(LocalDateTime.now())
                 .build();
@@ -51,7 +53,8 @@ public class NotificationService {
         SseEmitter emitter = emitters.get(memberId);
         if (emitter != null) {
             try {
-                emitter.send(SseEmitter.event().name("notification").data(message));
+                NotificationDto.NotificationResponse response = new NotificationDto.NotificationResponse(message, type, url);
+                emitter.send(SseEmitter.event().name("notification").data(response));
             } catch (Exception e) {
                 emitters.remove(memberId); // 실패 시 연결 제거
             }

--- a/src/main/java/itstime/reflog/notification/service/NotificationService.java
+++ b/src/main/java/itstime/reflog/notification/service/NotificationService.java
@@ -26,7 +26,7 @@ public class NotificationService {
         // 1. 멤버 조회
         Member member = memberServiceHelper.findMemberByUuid(memberId);
 
-        SseEmitter emitter = new SseEmitter(60 * 1000L); // 60초 동안 연결 유지
+        SseEmitter emitter = new SseEmitter(60 * 60 * 1000L); // 3600초 = 1시간 동안 연결 유지
         emitters.put(member.getId(), emitter);
 
         // 연결 종료 시 제거

--- a/src/main/java/itstime/reflog/postlike/service/PostLikeService.java
+++ b/src/main/java/itstime/reflog/postlike/service/PostLikeService.java
@@ -185,7 +185,7 @@ public class PostLikeService {
         notificationService.sendNotification(
                 receiver.getId(),
                 nickname + " 님이 " + title + "에 좋아요를 눌렀습니다.",
-                NotificationType.POSTLIKE
+                NotificationType.COMMUNITY
         );
     }
 
@@ -199,7 +199,7 @@ public class PostLikeService {
         notificationService.sendNotification(
                 receiver.getId(),
                 nickname + " 님이 " + title + "에 좋아요를 눌렀습니다.",
-                NotificationType.POSTLIKE
+                NotificationType.COMMUNITY
         );
     }
 }

--- a/src/main/java/itstime/reflog/postlike/service/PostLikeService.java
+++ b/src/main/java/itstime/reflog/postlike/service/PostLikeService.java
@@ -185,7 +185,8 @@ public class PostLikeService {
         notificationService.sendNotification(
                 receiver.getId(),
                 nickname + " 님이 " + title + "에 좋아요를 눌렀습니다.",
-                NotificationType.COMMUNITY
+                NotificationType.COMMUNITY,
+                "/api/v1/communities/" + community.getId()
         );
     }
 
@@ -199,7 +200,8 @@ public class PostLikeService {
         notificationService.sendNotification(
                 receiver.getId(),
                 nickname + " 님이 " + title + "에 좋아요를 눌렀습니다.",
-                NotificationType.COMMUNITY
+                NotificationType.COMMUNITY,
+                "/api/v1/retrospect/?retrospectId=" + retrospect.getId()
         );
     }
 }

--- a/src/main/java/itstime/reflog/postlike/service/PostLikeService.java
+++ b/src/main/java/itstime/reflog/postlike/service/PostLikeService.java
@@ -9,6 +9,8 @@ import itstime.reflog.member.domain.Member;
 import itstime.reflog.member.repository.MemberRepository;
 import itstime.reflog.mypage.domain.MyPage;
 import itstime.reflog.mypage.repository.MyPageRepository;
+import itstime.reflog.notification.domain.NotificationType;
+import itstime.reflog.notification.service.NotificationService;
 import itstime.reflog.postlike.domain.PopularPost;
 import itstime.reflog.member.service.MemberServiceHelper;
 import itstime.reflog.mission.service.MissionService;
@@ -37,13 +39,11 @@ public class PostLikeService {
     private final PopularPostRepository popularPostRepository;
     private final MemberServiceHelper memberServiceHelper;
     private final MissionService missionService;
-
-
-
+    private final NotificationService notificationService;
     private final MemberRepository memberRepository;
 
     @Transactional
-    public void togglePostLike(String memberId, Long postId, String postType){
+    public void togglePostLike(String memberId, Long postId, String postType) {
         Member member = memberServiceHelper.findMemberByUuid(memberId);
 
         MyPage myPage = myPageRepository.findByMember(member)
@@ -52,16 +52,16 @@ public class PostLikeService {
         PostLike postLike;
 
         //1. 글 유형에 따라 다른 엔티티에서 테이블 가져오기
-        if (PostType.COMMUNITY == PostType.valueOf(postType)){
+        if (PostType.COMMUNITY == PostType.valueOf(postType)) {
             Community community = communityRepository.findById(postId)
-                    .orElseThrow(()-> new GeneralException(ErrorStatus._COMMUNITY_NOT_FOUND));
+                    .orElseThrow(() -> new GeneralException(ErrorStatus._COMMUNITY_NOT_FOUND));
 
             //커뮤니티, 멤버 id와 일치하는 좋아요 가져오기
             postLike = postLikeRepository.findByMemberAndCommunity(member, community)
                     .orElse(null);
 
-            //2.좋아요 존재 여부 확인
-            if (postLike != null){
+            //2. 좋아요 존재 여부 확인
+            if (postLike != null) {
                 //좋아요가 이미 있다면 테이블 삭제
                 postLikeRepository.delete(postLike);
             } else {
@@ -76,18 +76,20 @@ public class PostLikeService {
 
                 // 미션
                 missionService.incrementMissionProgress(member.getId(), myPage, POWER_OF_HEART);
+
+                // 알림
+                sendCommunityLikeNotification(community, member);
             }
-        }
-        else if (PostType.RETROSPECT == PostType.valueOf(postType)){
+        } else if (PostType.RETROSPECT == PostType.valueOf(postType)) {
             Retrospect retrospect = retrospectRepository.findById(postId)
-                    .orElseThrow(()-> new GeneralException(ErrorStatus._RETROSPECT_NOT_FOUND));
+                    .orElseThrow(() -> new GeneralException(ErrorStatus._RETROSPECT_NOT_FOUND));
 
             //회고일지, 멤버 id와 일치하는 좋아요 가져오기
             postLike = postLikeRepository.findByMemberAndRetrospect(member, retrospect)
                     .orElse(null);
 
             //2.좋아요 존재 여부 확인
-            if (postLike != null){
+            if (postLike != null) {
                 //좋아요가 이미 있다면 테이블 삭제
                 postLikeRepository.delete(postLike);
             } else {
@@ -102,6 +104,9 @@ public class PostLikeService {
 
                 // 미션
                 missionService.incrementMissionProgress(member.getId(), myPage, POWER_OF_HEART);
+
+                // 알림
+                sendRetrospectLikeNotification(retrospect, member);
             }
         }
         //3. enum으로 설정하지 않은 글 유형이 올 경우 에러 출력
@@ -113,12 +118,12 @@ public class PostLikeService {
 
     //게시물마다 좋아요 갯수 항상 0이상이므로 int로
     @Transactional
-    public int getSumCommunityPostLike(Community community){
+    public int getSumCommunityPostLike(Community community) {
         return postLikeRepository.countByCommunity(community);
     }
 
     @Transactional
-    public int getSumRetrospectPostLike(Retrospect retrospect){
+    public int getSumRetrospectPostLike(Retrospect retrospect) {
         return postLikeRepository.countByRetrospect(retrospect);
     }
 
@@ -168,5 +173,33 @@ public class PostLikeService {
         });
 
         return combinedCategoryResponses;
+    }
+
+    public void sendCommunityLikeNotification(Community community, Member sender) {
+        Member receiver = community.getMember(); // 알림 받는 자
+
+        String title = community.getTitle(); // 글 제목
+
+        String nickname = sender.getMyPage().getNickname(); // 좋아요 누른 자
+
+        notificationService.sendNotification(
+                receiver.getId(),
+                nickname + " 님이 " + title + "에 좋아요를 눌렀습니다.",
+                NotificationType.POSTLIKE
+        );
+    }
+
+    public void sendRetrospectLikeNotification(Retrospect retrospect, Member sender) {
+        Member receiver = retrospect.getMember(); // 알림 받는 자
+
+        String title = retrospect.getTitle(); // 글 제목
+
+        String nickname = sender.getMyPage().getNickname(); // 좋아요 누른 자
+
+        notificationService.sendNotification(
+                receiver.getId(),
+                nickname + " 님이 " + title + "에 좋아요를 눌렀습니다.",
+                NotificationType.POSTLIKE
+        );
     }
 }

--- a/src/main/java/itstime/reflog/schedule/controller/ScheduleController.java
+++ b/src/main/java/itstime/reflog/schedule/controller/ScheduleController.java
@@ -54,7 +54,7 @@ public class ScheduleController {
 
     @Operation(
             summary = "일정등록 조회 API",
-            description = "특정 회원의 특정 날짜에 해당하는 일정등록을 조회합니다.",
+            description = "특정 회원의 특정 날짜에 해당하는 일정등록을 조회합니다. 알림이 켜있을 경우 isOn이 true이다.",
             responses = {
                     @ApiResponse(
                             responseCode = "200",

--- a/src/main/java/itstime/reflog/schedule/domain/Schedule.java
+++ b/src/main/java/itstime/reflog/schedule/domain/Schedule.java
@@ -3,12 +3,10 @@ package itstime.reflog.schedule.domain;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import itstime.reflog.member.domain.Member;
 import itstime.reflog.schedule.dto.ScheduleDto;
-import itstime.reflog.todolist.dto.TodolistDto;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -29,9 +27,7 @@ public class Schedule {
     private String content;
 
     private Boolean allday;
-
-//    @Column(name = "created_date", nullable = false)
-//    private LocalDate createdDate;
+    private Boolean isOn;
 
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
@@ -49,6 +45,7 @@ public class Schedule {
         this.title = request.getTitle();
         this.content = request.getContent();
         this.allday = request.isAllday();
+        this.isOn = request.getIsOn();
         this.startDateTime = request.getStartDateTime();
         this.endDateTime = request.getEndDateTime();
         this.member = member;

--- a/src/main/java/itstime/reflog/schedule/dto/ScheduleDto.java
+++ b/src/main/java/itstime/reflog/schedule/dto/ScheduleDto.java
@@ -7,7 +7,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public class ScheduleDto {
@@ -23,6 +22,8 @@ public class ScheduleDto {
 
         private boolean allday;
 
+        private Boolean isOn;
+
         @NotNull(message = "startDateTime은 비어 있을 수 없습니다.")
         private LocalDateTime startDateTime;
 
@@ -37,6 +38,7 @@ public class ScheduleDto {
         private final String title;
         private final String content;
         private final boolean allday;
+        private Boolean isOn;
         private final LocalDateTime startDateTime;
         private final LocalDateTime endDateTime;
     }

--- a/src/main/java/itstime/reflog/schedule/service/ScheduleService.java
+++ b/src/main/java/itstime/reflog/schedule/service/ScheduleService.java
@@ -180,7 +180,8 @@ public class ScheduleService {
         notificationService.sendNotification(
                 memberId,
                 "오늘은 " + title + " D-day 입니다!",
-                NotificationType.SCHEDULE
+                NotificationType.SCHEDULE,
+                "api/v1/plan/schedule"
         );
     }
 }

--- a/src/main/java/itstime/reflog/schedule/service/ScheduleService.java
+++ b/src/main/java/itstime/reflog/schedule/service/ScheduleService.java
@@ -4,14 +4,24 @@ import itstime.reflog.common.code.status.ErrorStatus;
 import itstime.reflog.common.exception.GeneralException;
 import itstime.reflog.member.domain.Member;
 import itstime.reflog.member.service.MemberServiceHelper;
+import itstime.reflog.notification.domain.NotificationType;
+import itstime.reflog.notification.repository.NotificationRepository;
+import itstime.reflog.notification.service.NotificationService;
 import itstime.reflog.schedule.domain.Schedule;
 import itstime.reflog.schedule.dto.ScheduleDto;
 import itstime.reflog.schedule.repository.ScheduleRepository;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
 
 @Service
 @RequiredArgsConstructor
@@ -19,24 +29,51 @@ public class ScheduleService {
 
     private final ScheduleRepository scheduleRepository;
     private final MemberServiceHelper memberServiceHelper;
-
+    private final NotificationService notificationService;
+    private final NotificationRepository notificationRepository;
+    private final ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+    private final Map<Long, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
+    @PostConstruct
+    public void ScheduleService() {
+        taskScheduler.initialize(); // Initialize the scheduler
+    }
 
     @Transactional
     public void createSchedule(String memberId, ScheduleDto.ScheduleSaveOrUpdateRequest dto) {
-
+        // 1. 멤버 조회
         Member member = memberServiceHelper.findMemberByUuid(memberId);
 
-
+        // 일정 생성
         Schedule schedule = Schedule.builder()
                 .title(dto.getTitle())
                 .content(dto.getContent())
                 .allday(dto.isAllday())
+                .isOn(dto.getIsOn())
                 .startDateTime(dto.getStartDateTime())
                 .endDateTime(dto.getEndDateTime())
                 .member(member)
                 .build();
 
         scheduleRepository.save(schedule);
+
+        // 3. 알림
+        if(dto.getIsOn()){
+            LocalDateTime now = LocalDateTime.now();
+            LocalDateTime startDateTime = dto.getStartDateTime();
+
+            long delay = Duration.between(now, startDateTime).toMillis();
+
+            if (delay <= 0) {
+                throw new GeneralException(ErrorStatus._DELAY);
+            }
+
+            ScheduledFuture<?> future = taskScheduler.schedule(
+                    () -> sendScheduleNotification(member.getId(), schedule.getTitle()),
+                    new java.util.Date(System.currentTimeMillis() + delay)
+            );
+
+            scheduledTasks.put(member.getId(), future);
+        }
     }
 
     @Transactional
@@ -51,6 +88,7 @@ public class ScheduleService {
                 schedule.getTitle(),
                 schedule.getContent(),
                 schedule.getAllday(),
+                schedule.getIsOn(),
                 schedule.getStartDateTime(),
                 schedule.getEndDateTime()
         );
@@ -74,21 +112,75 @@ public class ScheduleService {
 
     @Transactional
     public void updateSchedule(Long scheduleId, String memberId, ScheduleDto.ScheduleSaveOrUpdateRequest request) {
+        // 1. 멤버 조회
+        Member member = memberServiceHelper.findMemberByUuid(memberId);
+
+        // 2. 일정 조회
         Schedule schedule = scheduleRepository.findById(scheduleId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._SCHEDULE_NOT_FOUND));
 
-        Member member = memberServiceHelper.findMemberByUuid(memberId);
-
+        // 3. 일정 업데이트
         schedule.update(request, member);
 
         scheduleRepository.save(schedule);
+
+        // 4. 알림
+        LocalDateTime startDateTime = request.getStartDateTime();
+        LocalDateTime now = LocalDateTime.now();
+
+        if (!request.getIsOn()) {
+            // 알림이 존재하면 삭제
+            if (scheduledTasks.containsKey(member.getId())) {
+                ScheduledFuture<?> future = scheduledTasks.get(member.getId());
+                if (!future.isDone()) {
+                    future.cancel(true);
+                    scheduledTasks.remove(member.getId());
+                }
+            }
+            return;
+        }
+
+        // isOn이 true
+        if (scheduledTasks.containsKey(member.getId())) {
+            ScheduledFuture<?> future = scheduledTasks.get(member.getId());
+            if (!future.isDone()) {
+                future.cancel(true);
+            }
+        }
+
+        if (startDateTime.isAfter(now)) {
+            ScheduledFuture<?> future = taskScheduler.schedule(
+                    () -> sendScheduleNotification(member.getId(), schedule.getTitle()),
+                    java.util.Date.from(startDateTime.atZone(java.time.ZoneId.systemDefault()).toInstant())
+            );
+            scheduledTasks.put(member.getId(), future);
+        }
     }
 
     @Transactional
     public void deleteSchedule(Long scheduleId) {
+        // 1. 일정 조회
         Schedule schedule = scheduleRepository.findById(scheduleId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._SCHEDULE_NOT_FOUND));
 
+        // 2. 일정 삭제
         scheduleRepository.delete(schedule);
+
+        // 3. 알림 삭제
+        if (scheduledTasks.containsKey(schedule.getMember().getId())) {
+            ScheduledFuture<?> future = scheduledTasks.get(schedule.getMember().getId());
+            future.cancel(true);
+            scheduledTasks.remove(schedule.getMember().getId());
+
+            notificationRepository.deleteByMemberId(schedule.getMember().getId());
+        }
+    }
+
+    private void sendScheduleNotification(Long memberId, String title) {
+        notificationService.sendNotification(
+                memberId,
+                "오늘은 " + title + " D-day 입니다!",
+                NotificationType.SCHEDULE
+        );
     }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #68 

## 🔑 Key Changes

1. 내용
    - 모든 알림 다 해놓음 ( 알림에는 message, url, type 들어감, postman으로는 실시간 알림 테스트 성공했음, repo에도 잘 들어가는 것 확인 )
    - 미션/배지 알림 -> 처음 + n회 달성했을 때, 최종 달성했을 때
    - 분석보고서 알림 -> 주간, 월간
    - 학습플랜 알림 -> 일정등록에서 시작일 시간에 맞춰서 D-DAY 알림 ( 알림은 예약 해둠, 나중에 취소 가능 )
    - 커뮤니티 알림 -> 게시글 좋아요, 댓글 알림
    
    - 마이페이지에 알림 설정 해놓음




## 📸 Screenshot
![image](https://github.com/user-attachments/assets/2e86ebd7-b78c-4132-ae1b-927c532c7189)

