### PR TITLE
Feat: nginx, https 배포

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,31 @@ services:
     networks:
       - app-network
 
+  nginx:
+    image: nginx:latest
+    container_name: nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/conf:/etc/nginx/conf.d
+      - ./nginx/certbot/conf:/etc/letsencrypt
+      - ./nginx/certbot/www:/var/www/certbot
+    depends_on:
+      - app
+      - certbot
+    networks:
+      - app-network
+
+  certbot:
+    image: certbot/certbot
+    container_name: certbot
+    volumes:
+      - ./nginx/certbot/conf:/etc/letsencrypt
+      - ./nginx/certbot/www:/var/www/certbot
+    networks:
+      - app-network
+
 networks:
   app-network:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,6 @@ version: '3.8'
 services:
   app:
     image: yeoljeongping/reflogdocker
-    deploy:
-      resources:
-        limits:
-          memory: 512M
     ports:
       - "8080:8080"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,10 @@ version: '3.8'
 services:
   app:
     image: yeoljeongping/reflogdocker
+    deploy:
+      resources:
+        limits:
+          memory: 512M
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #72 

## 🔑 Key Changes

1. 내용
    - Nginx 설정

      HTTP 요청을 HTTPS로 리다이렉트하도록 Nginx 설정을 구성.
      SSL 인증서 경로(/etc/letsencrypt/live/network-chat.store/)를 설정하여 HTTPS 트래픽 처리 추가.
      
     - Certbot을 활용한 SSL 인증서 발급

       Certbot 컨테이너를 사용하여 Let's Encrypt 인증서 발급.
       도메인: network-chat.store, www.network-chat.store.
       인증서 저장 경로:
            인증서: /etc/letsencrypt/live/network-chat.store/fullchain.pem.
            개인 키: /etc/letsencrypt/live/network-chat.store/privkey.pem.
            
     - Docker Compose 설정

        nginx와 certbot 간의 인증서 데이터 공유를 위해 볼륨 매핑 추가.
        nginx의 포트 80(HTTP)과 443(HTTPS)을 열어 트래픽 처리.

## 📸 Screenshot
https://www.network-chat.store/swagger-ui/index.html#/
