### PR TITLE
Modify: 커뮤니티 조회 API 커뮤니티 글 id 데이터 추가

### DIFF
--- a/src/main/java/itstime/reflog/community/dto/CommunityDto.java
+++ b/src/main/java/itstime/reflog/community/dto/CommunityDto.java
@@ -45,6 +45,7 @@ public class CommunityDto {
 		private Boolean isLike;
 		private int totalLike;
 		private Long totalComment;
+		private Long postId;
 
 		public static CombinedCategoryResponse fromCommunity(Community community, String writer, Boolean isLike, Integer totalLike, Long totalComment) {
 			return CombinedCategoryResponse.builder()
@@ -57,6 +58,7 @@ public class CommunityDto {
 					.totalComment(totalComment)
 					.totalLike(totalLike)
 					.writer(writer)
+					.postId(community.getId())
 					.build();
 		}
 
@@ -74,6 +76,7 @@ public class CommunityDto {
 					.totalLike(totalLike)
 					.totalComment(totalComment)
 					.writer(writer)
+					.postId(retrospect.getId())
 					.build();
 		}
 	}

--- a/src/main/java/itstime/reflog/community/dto/CommunityDto.java
+++ b/src/main/java/itstime/reflog/community/dto/CommunityDto.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 
 import itstime.reflog.comment.dto.CommentDto;
 import itstime.reflog.community.domain.Community;
+import itstime.reflog.postlike.domain.enums.PostType;
 import itstime.reflog.retrospect.domain.Retrospect;
 import lombok.*;
 
@@ -46,6 +47,7 @@ public class CommunityDto {
 		private int totalLike;
 		private Long totalComment;
 		private Long postId;
+		private PostType postType;
 
 		public static CombinedCategoryResponse fromCommunity(Community community, String writer, Boolean isLike, Integer totalLike, Long totalComment) {
 			return CombinedCategoryResponse.builder()
@@ -59,6 +61,7 @@ public class CommunityDto {
 					.totalLike(totalLike)
 					.writer(writer)
 					.postId(community.getId())
+					.postType(PostType.COMMUNITY)
 					.build();
 		}
 
@@ -77,6 +80,7 @@ public class CommunityDto {
 					.totalComment(totalComment)
 					.writer(writer)
 					.postId(retrospect.getId())
+					.postType(PostType.RETROSPECT)
 					.build();
 		}
 	}


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #74 

## 🔑 Key Changes

1. 내용
    - 아래 사진의 커뮤니티 상세 조회를 제외한 조회 api들에서 id값이 빠져있어 추가해뒀습니다!
    - dto에 id 필드 추가한거여서 크게 변화는 없습니다
    - 회고일지/커뮤니티 id값이 같을 수 있기 때문에 postType을 enum으로 만들둔거를 이용해 함께 넘겨주도록 했습니다!
![image](https://github.com/user-attachments/assets/ee350652-21e7-4a8e-a2ed-512203e5b256)


## 📸 Screenshot
<img width="1090" alt="스크린샷 2025-01-14 오전 1 11 07" src="https://github.com/user-attachments/assets/d2591e58-87e4-4cb4-81f0-90891ed07f02" />

