### PR TITLE
Fix: app컨테이너 실행 안됨 오류 

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -86,6 +86,7 @@ jobs:
             echo "MAIL_USERNAME=${{ secrets.MAIL_USERNAME }}" >> ~/deploy/.env
             echo "MAIL_PASSWORD=${{ secrets.MAIL_PASSWORD }}" >> ~/deploy/.env
             
-            sudo docker-compose -f ~/deploy/docker-compose.yml pull
-            sudo docker-compose -f ~/deploy/docker-compose.yml up -d
+            sudo docker-compose -f ~/deploy/docker-compose.yml down
+            sudo docker-compose -f ~/deploy/docker-compose.yml pull --ignore-pull-failures
+            sudo docker-compose -f ~/deploy/docker-compose.yml up -d --force-recreate
             sudo docker image prune -f

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -47,7 +47,7 @@ jobs:
         run: docker network create app-network
 
       - name: Docker build and push
-        run: docker build -t yeoljeongping/reflogdocker .
+        run: docker build --no-cache -t yeoljeongping/reflogdocker .
 
       - name: docker login
         uses: docker/login-action@v2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,9 +28,11 @@ services:
       SPRING_REDIS_HOST: redis
       SPRING_REDIS_PORT: 6379
     depends_on:
-      - redis
+      redis:
+          condition: service_healthy
     networks:
       - app-network
+    restart: always
 
   redis:
     image: "redis:latest"
@@ -38,6 +40,11 @@ services:
       - "6379:6379"
     networks:
       - app-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
   nginx:
     image: nginx:latest
@@ -54,6 +61,7 @@ services:
       - certbot
     networks:
       - app-network
+    restart: always
 
   certbot:
     image: certbot/certbot
@@ -63,6 +71,7 @@ services:
       - ./nginx/certbot/www:/var/www/certbot
     networks:
       - app-network
+    restart: always
 
 networks:
   app-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.8'
 services:
   app:
     image: yeoljeongping/reflogdocker
+    pull_policy: always
     ports:
       - "8080:8080"
     environment:

--- a/src/main/java/itstime/reflog/config/SwaggerConfig.java
+++ b/src/main/java/itstime/reflog/config/SwaggerConfig.java
@@ -32,7 +32,7 @@ public class SwaggerConfig {
     private Info apiInfo() {
         return new Info()
                 .title("Reflog Swagger")
-                .description("Reflog Server API 명세서")
+                .description("Reflog Server API 명세서입니다.")
                 .version("1.0.0");
     }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #72

## 🔑 Key Changes

1. 내용
    - 앱 컨테이너 Health Check 추가

      초기 앱 컨테이너가 정상적으로 실행되지 않는 문제를 해결하기 위해 Docker Compose 설정에 Health Check를 추가.
      Redis 컨테이너는 redis-cli ping을 활용해 상태 확인.
      depends_on 조건에 Health Check를 적용하여 앱 컨테이너가 Redis가 정상 상태일 때만 실행되도록 설정.
     
    - 자동화 배포 코드 개선

       GitHub Actions에서 배포 시 코드 반영이 안 되는 문제를 해결하기 위해 기존 docker-compose up -d를 docker-compose 
 down && docker-compose up -d로 변경.
       배포 시 항상 최신 컨테이너를 실행하고 이전 컨테이너를 정리하도록 수정.

## 📸 Screenshot

