### PR TITLE
Refactor : 커뮤니티  조회 API 리팩토링

### DIFF
--- a/src/main/java/itstime/reflog/community/domain/Community.java
+++ b/src/main/java/itstime/reflog/community/domain/Community.java
@@ -42,12 +42,12 @@ public class Community {
 
 	private String content; // 게시글 내용
 
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection(fetch = FetchType.LAZY)
 	@CollectionTable(name = "community_post_types", joinColumns = @JoinColumn(name = "community_id"))
 	@Column(name = "post_type")
 	private List<String> postTypes; // 글 유형 (최대 2개)
 
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection(fetch = FetchType.LAZY)
 	@CollectionTable(name = "community_learning_types", joinColumns = @JoinColumn(name = "community_id"))
 	@Column(name = "learning_type")
 	private List<String> learningTypes; // 학습 유형 (최대 2개)

--- a/src/main/java/itstime/reflog/community/domain/Community.java
+++ b/src/main/java/itstime/reflog/community/domain/Community.java
@@ -26,12 +26,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@BatchSize(size = 50)
 public class Community {
 
 	@Id

--- a/src/main/java/itstime/reflog/community/domain/Community.java
+++ b/src/main/java/itstime/reflog/community/domain/Community.java
@@ -33,7 +33,6 @@ import org.hibernate.annotations.BatchSize;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@BatchSize(size = 50)
 public class Community {
 
 	@Id

--- a/src/main/java/itstime/reflog/community/dto/CommunityDto.java
+++ b/src/main/java/itstime/reflog/community/dto/CommunityDto.java
@@ -9,7 +9,9 @@ import itstime.reflog.community.domain.Community;
 import itstime.reflog.postlike.domain.enums.PostType;
 import itstime.reflog.retrospect.domain.Retrospect;
 import lombok.*;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class CommunityDto {
 
 	@Getter
@@ -49,13 +51,15 @@ public class CommunityDto {
 		private Long postId;
 		private PostType postType;
 
-		public static CombinedCategoryResponse fromCommunity(Community community, String writer, Boolean isLike, Integer totalLike, Long totalComment) {
+		public static CombinedCategoryResponse fromCommunity(Community community, List<String> postTypes,List<String> learningTypes, String writer, Boolean isLike, Integer totalLike, Long totalComment) {
+
+
 			return CombinedCategoryResponse.builder()
 					.title(community.getTitle())
 					.content(community.getContent())
 					.createdDate(community.getCreatedAt())
-					.postTypes(community.getPostTypes())
-					.learningTypes(community.getLearningTypes())
+					.postTypes(postTypes)
+					.learningTypes(learningTypes)
 					.isLike(isLike)
 					.totalComment(totalComment)
 					.totalLike(totalLike)

--- a/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
+++ b/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CommunityRepository extends JpaRepository<Community, Long> {
 
@@ -30,4 +31,6 @@ public interface CommunityRepository extends JpaRepository<Community, Long> {
 
     //내가 작성한 글 모두 찾기
     List<Community> findAllByMemberOrderByIdDesc(Member member);
+
+
 }

--- a/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
+++ b/src/main/java/itstime/reflog/community/repository/CommunityRepository.java
@@ -32,5 +32,4 @@ public interface CommunityRepository extends JpaRepository<Community, Long> {
     //내가 작성한 글 모두 찾기
     List<Community> findAllByMemberOrderByIdDesc(Member member);
 
-
 }

--- a/src/main/java/itstime/reflog/community/service/CommunityConverter.java
+++ b/src/main/java/itstime/reflog/community/service/CommunityConverter.java
@@ -1,0 +1,82 @@
+package itstime.reflog.community.service;
+
+import itstime.reflog.comment.repository.CommentRepository;
+import itstime.reflog.community.domain.Community;
+import itstime.reflog.community.dto.CommunityDto;
+import itstime.reflog.community.repository.CommunityRepository;
+import itstime.reflog.member.domain.Member;
+import itstime.reflog.mypage.domain.MyPage;
+import itstime.reflog.mypage.repository.MyPageRepository;
+import itstime.reflog.postlike.repository.PostLikeRepository;
+import itstime.reflog.postlike.service.PostLikeService;
+import itstime.reflog.retrospect.domain.Retrospect;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor //final로 설정한 것만 의존성 주임
+public class CommunityConverter {
+
+    private final MyPageRepository myPageRepository;
+    private final PostLikeRepository postLikeRepository;
+    private final PostLikeService postLikeService;
+    private final CommentRepository commentRepository;
+
+    @Transactional(readOnly = true)
+    public List<CommunityDto.CombinedCategoryResponse> communityResponseConverter(List<Community> communities, Member member) {
+
+        List<CommunityDto.CombinedCategoryResponse> responses = communities.stream()
+                .map(community -> {
+                    //마이페이지 레포지토리에서 닉네임 반환
+                    String nickname = myPageRepository.findByMember(community.getMember())
+                            .map(MyPage::getNickname)
+                            .orElse("닉네임 없음");
+
+                    List<String> communityPostTypes = new ArrayList<>(community.getPostTypes()); // 강제 초기화
+                    List<String> communityLearningTypes = new ArrayList<>(community.getLearningTypes()); // 강제 초기화
+
+                    //좋아요 있는지 없는지 플래그
+                    Boolean isLike = postLikeRepository.findLikeByMemberAndCommunity(member, community).isPresent();
+
+                    //게시물마다 좋아요 총 갯수 반환
+                    int totalLike = postLikeService.getSumCommunityPostLike(community);
+
+                    //게시물마다 댓글 수 반환
+                    Long totalComment = commentRepository.countByCommunity(community);
+                    return CommunityDto.CombinedCategoryResponse.fromCommunity(community,communityPostTypes, communityLearningTypes, nickname, isLike, totalLike, totalComment);
+                })
+                .collect(Collectors.toList());
+
+        return responses;
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommunityDto.CombinedCategoryResponse> retrospectResponseConverter(List<Retrospect> retrospects, Member member) {
+
+        List<CommunityDto.CombinedCategoryResponse> responses = retrospects.stream().map(
+                        retrospect -> {
+                            String nickname = myPageRepository.findByMember(retrospect.getMember())
+                                    .map(MyPage::getNickname)
+                                    .orElse("닉네임 없음");
+                            //좋아요 있는지 없는지 플래그
+                            Boolean isLike = postLikeRepository.findBookmarkByMemberAndRetrospect(member, retrospect).isPresent();
+
+                            //게시물마다 좋아요 총 갯수 반환
+                            int totalLike = postLikeService.getSumRetrospectPostLike(retrospect);
+
+                            //게시물마다 댓글 수 반환
+                            Long totalComment = commentRepository.countByRetrospect(retrospect);
+
+                            return CommunityDto.CombinedCategoryResponse.fromRetrospect(retrospect, nickname, isLike, totalLike, totalComment);
+                        })
+                .collect(Collectors.toList());
+
+        return responses;
+    }
+
+}

--- a/src/main/java/itstime/reflog/community/service/CommunityService.java
+++ b/src/main/java/itstime/reflog/community/service/CommunityService.java
@@ -229,6 +229,9 @@ public class CommunityService {
                             .map(MyPage::getNickname)
                             .orElse("닉네임 없음");
 
+                    List<String> communityPostTypes = new ArrayList<>(community.getPostTypes()); // 강제 초기화
+                    List<String> communityLearningTypes = new ArrayList<>(community.getLearningTypes()); // 강제 초기화
+
                     //좋아요 있는지 없는지 플래그
                     Boolean isLike = postLikeRepository.findLikeByMemberAndCommunity(member, community).isPresent();
 
@@ -237,7 +240,7 @@ public class CommunityService {
 
                     //게시물마다 댓글 수 반환
                     Long totalComment = commentRepository.countByCommunity(community);
-                    return CommunityDto.CombinedCategoryResponse.fromCommunity(community, nickname, isLike, totalLike, totalComment);
+                    return CommunityDto.CombinedCategoryResponse.fromCommunity(community,communityPostTypes, communityLearningTypes, nickname, isLike, totalLike, totalComment);
                 })
                 .collect(Collectors.toList());
 
@@ -283,6 +286,9 @@ public class CommunityService {
                             .map(MyPage::getNickname)
                             .orElse("닉네임 없음");
 
+                    List<String> postTypes = new ArrayList<>(community.getPostTypes()); // 강제 초기화
+                    List<String> learningTypes = new ArrayList<>(community.getLearningTypes()); // 강제 초기화
+
                     //좋아요 있는지 없는지 플래그
                     Boolean isLike = postLikeRepository.findLikeByMemberAndCommunity(member, community).isPresent();
 
@@ -291,7 +297,7 @@ public class CommunityService {
 
                     //게시물마다 댓글 수 반환
                     Long totalComment = commentRepository.countByCommunity(community);
-                    return CommunityDto.CombinedCategoryResponse.fromCommunity(community, nickname, isLike, totalLike, totalComment);
+                    return CommunityDto.CombinedCategoryResponse.fromCommunity(community,postTypes, learningTypes, nickname, isLike, totalLike, totalComment);
                 })
                 .collect(Collectors.toList());
 
@@ -352,6 +358,9 @@ public class CommunityService {
                             .map(MyPage::getNickname)
                             .orElse("닉네임 없음");
 
+                    List<String> postTypes = new ArrayList<>(community.getPostTypes()); // 강제 초기화
+                    List<String> learningTypes = new ArrayList<>(community.getLearningTypes()); // 강제 초기화
+
                     //좋아요 있는지 없는지 플래그
                     Boolean isLike = postLikeRepository.findBookmarkByMemberAndCommunity(member, community).isPresent();
 
@@ -361,7 +370,7 @@ public class CommunityService {
                     //게시물마다 댓글 수 반환
                     Long totalComment = commentRepository.countByCommunity(community);
 
-                    return CommunityDto.CombinedCategoryResponse.fromCommunity(community, nickname, isLike, totalLike, totalComment);
+                    return CommunityDto.CombinedCategoryResponse.fromCommunity(community,postTypes, learningTypes, nickname, isLike, totalLike, totalComment);
                 })
                 .collect(Collectors.toList());
 
@@ -388,12 +397,15 @@ public class CommunityService {
         List<MyPageDto.MyPagePostResponse> responses = communityList.stream()
                 .map(community -> {
 
+                    List<String> postTypes = new ArrayList<>(community.getPostTypes()); // 강제 초기화
+                    List<String> learningTypes = new ArrayList<>(community.getLearningTypes()); // 강제 초기화
+
                     // 좋아요 총 개수
                     int totalLike = postLikeService.getSumCommunityPostLike(community);
                     // 댓글 총 개수
                     long commentCount = commentRepository.countByCommunity(community);
 
-                    return MyPageDto.MyPagePostResponse.fromCommunity(community, totalLike, commentCount);
+                    return MyPageDto.MyPagePostResponse.fromCommunity(community, postTypes, learningTypes,totalLike, commentCount);
                 })
                 .collect(Collectors.toList());
 

--- a/src/main/java/itstime/reflog/community/service/CommunityService.java
+++ b/src/main/java/itstime/reflog/community/service/CommunityService.java
@@ -48,9 +48,9 @@ public class CommunityService {
     private final RetrospectRepository retrospectRepository;
     private final CommentRepository commentRepository;
     private final PostLikeService postLikeService;
-    private final PostLikeRepository postLikeRepository;
     private final MissionService missionService;
     private final MemberServiceHelper memberServiceHelper;
+    private final CommunityConverter communityConverter;
 
 
     @Transactional
@@ -222,52 +222,14 @@ public class CommunityService {
         }
 
         //커뮤니티 response형태로 반환 닉네임 추가
-        List<CommunityDto.CombinedCategoryResponse> responses = communities.stream()
-                .map(community -> {
-                    //마이페이지 레포지토리에서 닉네임 반환
-                    String nickname = myPageRepository.findByMember(community.getMember())
-                            .map(MyPage::getNickname)
-                            .orElse("닉네임 없음");
-
-                    List<String> communityPostTypes = new ArrayList<>(community.getPostTypes()); // 강제 초기화
-                    List<String> communityLearningTypes = new ArrayList<>(community.getLearningTypes()); // 강제 초기화
-
-                    //좋아요 있는지 없는지 플래그
-                    Boolean isLike = postLikeRepository.findLikeByMemberAndCommunity(member, community).isPresent();
-
-                    //게시물마다 좋아요 총 갯수 반환
-                    int totalLike = postLikeService.getSumCommunityPostLike(community);
-
-                    //게시물마다 댓글 수 반환
-                    Long totalComment = commentRepository.countByCommunity(community);
-                    return CommunityDto.CombinedCategoryResponse.fromCommunity(community,communityPostTypes, communityLearningTypes, nickname, isLike, totalLike, totalComment);
-                })
-                .collect(Collectors.toList());
+        List<CommunityDto.CombinedCategoryResponse> responses = communityConverter.communityResponseConverter(communities, member);
 
         //글 유형에 회고일지가 있는 경우
         if (postTypes != null && postTypes.contains("회고일지")) {
             List<Retrospect> retrospects = retrospectRepository.findByVisibilityIsTrue();
-            List<CommunityDto.CombinedCategoryResponse> retrospectResponses = retrospects.stream()
-                    .map(retrospect -> {
-                        String nickname = myPageRepository.findByMember(retrospect.getMember())
-                                .map(MyPage::getNickname)
-                                .orElse("닉네임 없음");
-
-                        //좋아요 있는지 없는지 플래그
-                        Boolean isLike = postLikeRepository.findLikeByMemberAndRetrospect(member, retrospect).isPresent();
-
-                        //게시물마다 좋아요 총 갯수 반환
-                        int totalLike = postLikeService.getSumRetrospectPostLike(retrospect);
-
-                        //게시물마다 댓글 수 반환
-                        Long totalComment = commentRepository.countByRetrospect(retrospect);
-
-                        return CommunityDto.CombinedCategoryResponse.fromRetrospect(retrospect, nickname, isLike, totalLike, totalComment);
-                    })
-                    .collect(Collectors.toList());
+            List<CommunityDto.CombinedCategoryResponse> retrospectResponses = communityConverter.retrospectResponseConverter(retrospects, member);
             responses.addAll(retrospectResponses); // 두 리스트 합치기(회고일지, 커뮤니티)
         }
-
         return responses;
     }
 
@@ -280,47 +242,11 @@ public class CommunityService {
         //커뮤니티 게시물 중 키워드가 일치하는 게시물 찾기
         List<Community> communities = communityRepository.searchCommunitiesByTitleContaining(title);
 
-        List<CommunityDto.CombinedCategoryResponse> responses = communities.stream()
-                .map(community -> {
-                    String nickname = myPageRepository.findByMember(community.getMember())
-                            .map(MyPage::getNickname)
-                            .orElse("닉네임 없음");
-
-                    List<String> postTypes = new ArrayList<>(community.getPostTypes()); // 강제 초기화
-                    List<String> learningTypes = new ArrayList<>(community.getLearningTypes()); // 강제 초기화
-
-                    //좋아요 있는지 없는지 플래그
-                    Boolean isLike = postLikeRepository.findLikeByMemberAndCommunity(member, community).isPresent();
-
-                    //게시물마다 좋아요 총 갯수 반환
-                    int totalLike = postLikeService.getSumCommunityPostLike(community);
-
-                    //게시물마다 댓글 수 반환
-                    Long totalComment = commentRepository.countByCommunity(community);
-                    return CommunityDto.CombinedCategoryResponse.fromCommunity(community,postTypes, learningTypes, nickname, isLike, totalLike, totalComment);
-                })
-                .collect(Collectors.toList());
-
+        List<CommunityDto.CombinedCategoryResponse> responses = communityConverter.communityResponseConverter(communities, member);
         //회고일지 게시물 중 키워드가 일치하는 게시물 찾기
         List<Retrospect> retrospects = retrospectRepository.findByTitleContainingAndVisibilityIsTrue(title);
 
-        List<CommunityDto.CombinedCategoryResponse> retrospectResponses = retrospects.stream()
-                .map(retrospect -> {
-                    String nickname = myPageRepository.findByMember(retrospect.getMember())
-                            .map(MyPage::getNickname)
-                            .orElse("닉네임 없음");
-                    //좋아요 있는지 없는지 플래그
-                    Boolean isLike = postLikeRepository.findLikeByMemberAndRetrospect(member, retrospect).isPresent();
-
-                    //게시물마다 좋아요 총 갯수 반환
-                    int totalLike = postLikeService.getSumRetrospectPostLike(retrospect);
-
-                    //게시물마다 댓글 수 반환
-                    Long totalComment = commentRepository.countByRetrospect(retrospect);
-
-                    return CommunityDto.CombinedCategoryResponse.fromRetrospect(retrospect, nickname, isLike, totalLike, totalComment);
-                })
-                .collect(Collectors.toList());
+        List<CommunityDto.CombinedCategoryResponse> retrospectResponses = communityConverter.retrospectResponseConverter(retrospects, member);
         responses.addAll(retrospectResponses); // 두 리스트 합치기(회고일지, 커뮤니티)
 
         return responses;
@@ -334,45 +260,9 @@ public class CommunityService {
         List<Retrospect> retrospects = retrospectRepository.findAllByVisibilityTrueOrderByCreatedDateDesc();
 
         //회고일지, 커뮤니티 리스트를 합쳐 하나의 리스트로
-        List<CommunityDto.CombinedCategoryResponse> responses = retrospects.stream().map(
-                        retrospect -> {
-                            String nickname = myPageRepository.findByMember(retrospect.getMember())
-                                    .map(MyPage::getNickname)
-                                    .orElse("닉네임 없음");
-                            //좋아요 있는지 없는지 플래그
-                            Boolean isLike = postLikeRepository.findBookmarkByMemberAndRetrospect(member, retrospect).isPresent();
+        List<CommunityDto.CombinedCategoryResponse> responses = communityConverter.retrospectResponseConverter(retrospects, member);
 
-                            //게시물마다 좋아요 총 갯수 반환
-                            int totalLike = postLikeService.getSumRetrospectPostLike(retrospect);
-
-                            //게시물마다 댓글 수 반환
-                            Long totalComment = commentRepository.countByRetrospect(retrospect);
-
-                            return CommunityDto.CombinedCategoryResponse.fromRetrospect(retrospect, nickname, isLike, totalLike, totalComment);
-                        })
-                .collect(Collectors.toList());
-
-        List<CommunityDto.CombinedCategoryResponse> communityResponses = communities.stream()
-                .map(community -> {
-                    String nickname = myPageRepository.findByMember(community.getMember())
-                            .map(MyPage::getNickname)
-                            .orElse("닉네임 없음");
-
-                    List<String> postTypes = new ArrayList<>(community.getPostTypes()); // 강제 초기화
-                    List<String> learningTypes = new ArrayList<>(community.getLearningTypes()); // 강제 초기화
-
-                    //좋아요 있는지 없는지 플래그
-                    Boolean isLike = postLikeRepository.findBookmarkByMemberAndCommunity(member, community).isPresent();
-
-                    //게시물마다 좋아요 총 갯수 반환
-                    int totalLike = postLikeService.getSumCommunityPostLike(community);
-
-                    //게시물마다 댓글 수 반환
-                    Long totalComment = commentRepository.countByCommunity(community);
-
-                    return CommunityDto.CombinedCategoryResponse.fromCommunity(community,postTypes, learningTypes, nickname, isLike, totalLike, totalComment);
-                })
-                .collect(Collectors.toList());
+        List<CommunityDto.CombinedCategoryResponse> communityResponses = communityConverter.communityResponseConverter(communities, member);
 
         responses.addAll(communityResponses);
 

--- a/src/main/java/itstime/reflog/mypage/dto/MyPageDto.java
+++ b/src/main/java/itstime/reflog/mypage/dto/MyPageDto.java
@@ -60,7 +60,7 @@ public class MyPageDto {
         private int totalLike;
         private long commentCount;
 
-        public static MyPagePostResponse fromCommunity(Community community, int totalLike, long commentCount){
+        public static MyPagePostResponse fromCommunity(Community community, List<String> postTypes,List<String> learningTypes, int totalLike, long commentCount){
             return MyPagePostResponse.builder()
                     .id(community.getId())
                     .title(community.getTitle())

--- a/src/main/java/itstime/reflog/mypage/service/MyPageService.java
+++ b/src/main/java/itstime/reflog/mypage/service/MyPageService.java
@@ -23,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -142,12 +143,15 @@ public class MyPageService {
         List<MyPageDto.MyPagePostResponse> responses = communityList.stream()
                 .map(community -> {
 
+                    List<String> postTypes = new ArrayList<>(community.getPostTypes()); // 강제 초기화
+                    List<String> learningTypes = new ArrayList<>(community.getLearningTypes()); // 강제 초기화
+
                     // 좋아요 총 개수
                     int totalLike = postLikeService.getSumCommunityPostLike(community);
                     // 댓글 총 개수
                     long commentCount = commentRepository.countByCommunity(community);
 
-                    return MyPageDto.MyPagePostResponse.fromCommunity(community, totalLike, commentCount);
+                    return MyPageDto.MyPagePostResponse.fromCommunity(community, postTypes, learningTypes, totalLike, commentCount);
                 })
                 .collect(Collectors.toList());
 
@@ -181,13 +185,17 @@ public class MyPageService {
         // 3. 내가 좋아요 한 커뮤니티 글 정리
         List<MyPageDto.MyPagePostResponse> responses = postLikeList.stream()
                 .map(postLike -> {
+                    Community community = postLike.getCommunity();
+
+                    List<String> postTypes = new ArrayList<>(community.getPostTypes()); // 강제 초기화
+                    List<String> learningTypes = new ArrayList<>(community.getLearningTypes()); // 강제 초기화
 
                     // 좋아요 총 개수
                     int totalLike = postLikeService.getSumCommunityPostLike(postLike.getCommunity());
                     // 댓글 총 개수
                     long commentCount = commentRepository.countByCommunity(postLike.getCommunity());
 
-                    return MyPageDto.MyPagePostResponse.fromCommunity(postLike.getCommunity(), totalLike, commentCount);
+                    return MyPageDto.MyPagePostResponse.fromCommunity(community, postTypes, learningTypes, totalLike, commentCount);
                 })
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #80 

## 🔑 Key Changes

1. 내용
    - Community 도메인에서 learningTypes, postTypes이 즉시로딩으로 되어있어서 지연 로딩으로 바꿈.. 컬렉션 타입이기 때문에 패치조인이 되지 않아 트랜젝션 내에서 초기화하도록 함
    - 지연로딩으로 설정한 컬렉션은 쿼리들을 한번에 가져올 수 있도록 배치 사이즈 설정 추가
    - + 커뮤니티 서비스에서 중복되는 코드 클래스로 따로 뺌

## 📸 Screenshot
<img width="823" alt="image" src="https://github.com/user-attachments/assets/9750216a-e59f-4d30-a750-4ff27ecbda41" />


